### PR TITLE
✨ Add Order Summary Live Component for Stripe Web Elements

### DIFF
--- a/config/app/twig_hooks/shop/order_pay/web_elements.yaml
+++ b/config/app/twig_hooks/shop/order_pay/web_elements.yaml
@@ -1,18 +1,42 @@
 sylius_twig_hooks:
     hooks:
-
-        'flux_se_sylius_stripe_plugin.order_pay.stripe_web_elements.capture#javascripts':
+        "flux_se_sylius_stripe_plugin.order_pay.stripe_web_elements.capture#javascripts":
             stripe_lib:
-                template: '@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript.html.twig'
+                template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript.html.twig"
                 priority: 100
             stripe_appearance:
-                template: '@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript_appearance.html.twig'
+                template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript_appearance.html.twig"
                 priority: 200
             stripe_payment_intent:
-                template: '@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript_common.html.twig'
+                template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript_common.html.twig"
                 priority: 0
 
-        'flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture':
+        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture":
             form:
-                template: '@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/form.html.twig'
+                template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/form.html.twig"
+                priority: 0
+
+        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.sidebar":
+            sidebar:
+                component: "sylius_shop:order_pay:web_elements:summary"
+                priority: 100
+
+        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.sidebar.summary":
+            items_total:
+                template: "@SyliusShop/cart/index/content/form/sections/general/summary/items_total.html.twig"
+                priority: 500
+            discount:
+                template: "@SyliusShop/cart/index/content/form/sections/general/summary/discount.html.twig"
+                priority: 400
+            estimated_cost:
+                template: "@SyliusShop/cart/index/content/form/sections/general/summary/estimated_cost.html.twig"
+                priority: 300
+            taxes_total:
+                template: "@SyliusShop/cart/index/content/form/sections/general/summary/taxes_total.html.twig"
+                priority: 200
+            order_total:
+                template: "@SyliusShop/cart/index/content/form/sections/general/summary/order_total.html.twig"
+                priority: 100
+            base_currency_order_total:
+                template: "@SyliusShop/cart/index/content/form/sections/general/summary/base_currency_order_total.html.twig"
                 priority: 0

--- a/config/app/twig_hooks/shop/order_pay/web_elements.yaml
+++ b/config/app/twig_hooks/shop/order_pay/web_elements.yaml
@@ -11,32 +11,12 @@ sylius_twig_hooks:
                 template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/javascript_common.html.twig"
                 priority: 0
 
-        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture":
-            form:
-                template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/form.html.twig"
+        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.content":
+            content:
+                component: "sylius_shop:order_pay:web_elements:content"
                 priority: 0
 
-        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.sidebar":
-            sidebar:
-                component: "sylius_shop:order_pay:web_elements:summary"
-                priority: 100
-
-        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.sidebar.summary":
-            items_total:
-                template: "@SyliusShop/cart/index/content/form/sections/general/summary/items_total.html.twig"
-                priority: 500
-            discount:
-                template: "@SyliusShop/cart/index/content/form/sections/general/summary/discount.html.twig"
-                priority: 400
-            estimated_cost:
-                template: "@SyliusShop/cart/index/content/form/sections/general/summary/estimated_cost.html.twig"
-                priority: 300
-            taxes_total:
-                template: "@SyliusShop/cart/index/content/form/sections/general/summary/taxes_total.html.twig"
-                priority: 200
-            order_total:
-                template: "@SyliusShop/cart/index/content/form/sections/general/summary/order_total.html.twig"
-                priority: 100
-            base_currency_order_total:
-                template: "@SyliusShop/cart/index/content/form/sections/general/summary/base_currency_order_total.html.twig"
+        "flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.form":
+            form:
+                template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/form.html.twig"
                 priority: 0

--- a/config/services/integrations/sylius_shop/live_component.yaml
+++ b/config/services/integrations/sylius_shop/live_component.yaml
@@ -3,7 +3,6 @@ services:
         arguments:
             - "@request_stack"
             - "@sylius.repository.payment_request"
-            - "@monolog.logger"
         tags:
             - name: "twig.component"
               key: "sylius_shop:order_pay:web_elements:content"

--- a/config/services/integrations/sylius_shop/live_component.yaml
+++ b/config/services/integrations/sylius_shop/live_component.yaml
@@ -1,0 +1,10 @@
+services:
+    FluxSE\SyliusStripePlugin\Twig\Component\WebElements\SummaryPaymentComponent:
+        arguments:
+            - "@request_stack"
+            - "@sylius.repository.payment_request"
+            - "@monolog.logger"
+        tags:
+            - name: "twig.component"
+              key: "sylius_shop:order_pay:web_elements:summary"
+              template: "@SyliusShop/cart/index/content/form/sections/general/summary.html.twig"

--- a/config/services/integrations/sylius_shop/live_component.yaml
+++ b/config/services/integrations/sylius_shop/live_component.yaml
@@ -6,5 +6,5 @@ services:
             - "@monolog.logger"
         tags:
             - name: "twig.component"
-              key: "sylius_shop:order_pay:web_elements:summary"
-              template: "@SyliusShop/cart/index/content/form/sections/general/summary.html.twig"
+              key: "sylius_shop:order_pay:web_elements:content"
+              template: "@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture/content.html.twig"

--- a/src/DependencyInjection/CompilerPass/LiveTwigComponentCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/LiveTwigComponentCompilerPass.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace FluxSE\SyliusStripePlugin\DependencyInjection\CompilerPass;
 
 use FluxSE\SyliusStripePlugin\Twig\Component\AdminPaymentMethod\FormComponent;
+use FluxSE\SyliusStripePlugin\Twig\Component\WebElements\SummaryPaymentComponent;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 final class LiveTwigComponentCompilerPass implements CompilerPassInterface
@@ -26,5 +28,19 @@ final class LiveTwigComponentCompilerPass implements CompilerPassInterface
             ->addTag('sylius.live_component.admin', $tagConfig[0])
             ->clearTag('sylius.twig_component')
         ;
+
+        $summaryComponentDefinition = new Definition(SummaryPaymentComponent::class);
+        $summaryComponentDefinition
+            ->setArguments([
+                new Reference('request_stack'),
+                new Reference('sylius.repository.payment_request'),
+                new Reference('monolog.logger'),
+            ])
+            ->addTag('twig.component', [
+                'key' => 'sylius_shop:order_pay:web_elements:summary',
+                'template' => '@SyliusShop/cart/index/content/form/sections/general/summary.html.twig'
+            ]);
+
+        $container->setDefinition('sylius_live_component.payment_summary', $summaryComponentDefinition);
     }
 }

--- a/src/DependencyInjection/CompilerPass/LiveTwigComponentCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/LiveTwigComponentCompilerPass.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace FluxSE\SyliusStripePlugin\DependencyInjection\CompilerPass;
 
 use FluxSE\SyliusStripePlugin\Twig\Component\AdminPaymentMethod\FormComponent;
-use FluxSE\SyliusStripePlugin\Twig\Component\WebElements\SummaryPaymentComponent;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 final class LiveTwigComponentCompilerPass implements CompilerPassInterface
@@ -28,19 +26,5 @@ final class LiveTwigComponentCompilerPass implements CompilerPassInterface
             ->addTag('sylius.live_component.admin', $tagConfig[0])
             ->clearTag('sylius.twig_component')
         ;
-
-        $summaryComponentDefinition = new Definition(SummaryPaymentComponent::class);
-        $summaryComponentDefinition
-            ->setArguments([
-                new Reference('request_stack'),
-                new Reference('sylius.repository.payment_request'),
-                new Reference('monolog.logger'),
-            ])
-            ->addTag('twig.component', [
-                'key' => 'sylius_shop:order_pay:web_elements:summary',
-                'template' => '@SyliusShop/cart/index/content/form/sections/general/summary.html.twig'
-            ]);
-
-        $container->setDefinition('sylius_live_component.payment_summary', $summaryComponentDefinition);
     }
 }

--- a/src/Exception/WebElementsSummaryException.php
+++ b/src/Exception/WebElementsSummaryException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Exception;
+
+use DomainException;
+
+class WebElementsSummaryException extends DomainException
+{
+}

--- a/src/Twig/Component/WebElements/SummaryPaymentComponent.php
+++ b/src/Twig/Component/WebElements/SummaryPaymentComponent.php
@@ -28,8 +28,8 @@ class SummaryPaymentComponent
     use TemplatePropTrait;
 
     #[LiveProp(hydrateWith: 'hydrateResource', dehydrateWith: 'dehydrateResource')]
-    #[ExposeInTemplate('cart')]
-    public ?ResourceInterface $cart = null;
+    #[ExposeInTemplate('order')]
+    public ?ResourceInterface $order = null;
 
     public function __construct(
         private readonly RequestStack $requestStack,
@@ -40,7 +40,7 @@ class SummaryPaymentComponent
 
     public function mount(): void
     {
-        $this->cart = $this->getOrderFromPaymentRequest();
+        $this->order = $this->getOrderFromPaymentRequest();
     }
 
     private function getOrderFromPaymentRequest(): OrderInterface

--- a/src/Twig/Component/WebElements/SummaryPaymentComponent.php
+++ b/src/Twig/Component/WebElements/SummaryPaymentComponent.php
@@ -42,10 +42,10 @@ class SummaryPaymentComponent
 
     private function getOrderFromPaymentRequest(): OrderInterface
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if ($request === null) {
-            throw new WebElementsSummaryException('No active request found.');
-        }
+        $request = $this->ensureExists(
+                $this->requestStack->getCurrentRequest(),
+                'No active request found.'
+        );
 
         $tokenHash = $this->ensureExists(
             $request->get('hash'),

--- a/src/Twig/Component/WebElements/SummaryPaymentComponent.php
+++ b/src/Twig/Component/WebElements/SummaryPaymentComponent.php
@@ -40,12 +40,7 @@ class SummaryPaymentComponent
 
     public function mount(): void
     {
-        try {
-            $this->cart = $this->getOrderFromPaymentRequest();
-        } catch (WebElementsSummaryException $e) {
-            $this->logger->error(sprintf('[Payment Summary] Error: %s', $e->getMessage()));
-            throw $e;
-        }
+        $this->cart = $this->getOrderFromPaymentRequest();
     }
 
     private function getOrderFromPaymentRequest(): OrderInterface
@@ -65,10 +60,7 @@ class SummaryPaymentComponent
             sprintf('No payment request found for token hash "%s".', $tokenHash)
         );
 
-        $payment = $this->ensureExists(
-            $paymentRequest->getPayment(),
-            sprintf('No payment found for token hash "%s".', $tokenHash)
-        );
+        $payment = $paymentRequest->getPayment();
 
         $order = $this->ensureExists(
             $payment->getOrder(),

--- a/src/Twig/Component/WebElements/SummaryPaymentComponent.php
+++ b/src/Twig/Component/WebElements/SummaryPaymentComponent.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace FluxSE\SyliusStripePlugin\Twig\Component\WebElements;
 
 use FluxSE\SyliusStripePlugin\Exception\WebElementsSummaryException;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Sylius\Bundle\UiBundle\Twig\Component\ResourceLivePropTrait;
 use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -34,7 +32,6 @@ class SummaryPaymentComponent
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly PaymentRequestRepositoryInterface $paymentRequestRepository,
-        private readonly LoggerInterface $logger = new NullLogger(),
     ) {
     }
 

--- a/src/Twig/Component/WebElements/SummaryPaymentComponent.php
+++ b/src/Twig/Component/WebElements/SummaryPaymentComponent.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Twig\Component\WebElements;
+
+use FluxSE\SyliusStripePlugin\Exception\WebElementsSummaryException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Sylius\Bundle\UiBundle\Twig\Component\ResourceLivePropTrait;
+use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
+use Sylius\Resource\Model\ResourceInterface;
+use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+
+#[AsLiveComponent()]
+class SummaryPaymentComponent
+{
+    use DefaultActionTrait;
+    use HookableLiveComponentTrait;
+    use ResourceLivePropTrait;
+    use TemplatePropTrait;
+
+    #[LiveProp(hydrateWith: 'hydrateResource', dehydrateWith: 'dehydrateResource')]
+    #[ExposeInTemplate('cart')]
+    public ?ResourceInterface $cart = null;
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly PaymentRequestRepositoryInterface $paymentRequestRepository,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function mount(): void
+    {
+        try {
+            $this->cart = $this->getOrderFromPaymentRequest();
+        } catch (WebElementsSummaryException $e) {
+            $this->logger->error(sprintf('[Payment Summary] Error: %s', $e->getMessage()));
+            throw $e;
+        }
+    }
+
+    private function getOrderFromPaymentRequest(): OrderInterface
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request === null) {
+            throw new WebElementsSummaryException('No active request found.');
+        }
+
+        $tokenHash = $this->ensureExists(
+            $request->get('hash'),
+            'Token hash is required to load the payment summary component.'
+        );
+
+        $paymentRequest = $this->ensureExists(
+            $this->paymentRequestRepository->findOneBy(['hash' => $tokenHash]),
+            sprintf('No payment request found for token hash "%s".', $tokenHash)
+        );
+
+        $payment = $this->ensureExists(
+            $paymentRequest->getPayment(),
+            sprintf('No payment found for token hash "%s".', $tokenHash)
+        );
+
+        $order = $this->ensureExists(
+            $payment->getOrder(),
+            sprintf('No order found for token hash "%s".', $tokenHash)
+        );
+
+        return $order;
+    }
+
+    private function ensureExists(mixed $value, string $message): mixed
+    {
+        if ($value === null) {
+            throw new WebElementsSummaryException($message);
+        }
+
+        return $value;
+    }
+}

--- a/templates/shop/order_pay/web_elements/capture.html.twig
+++ b/templates/shop/order_pay/web_elements/capture.html.twig
@@ -4,6 +4,6 @@
 
 {% block title %}{{ 'flux_se_sylius_stripe_plugin.gateway_factory.stripe_web_elements'|trans }} | {{ parent() }}{% endblock %}
 
-{% block body %}
+{% block content %}
     {% hook 'flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture' %}
 {% endblock %}

--- a/templates/shop/order_pay/web_elements/capture.html.twig
+++ b/templates/shop/order_pay/web_elements/capture.html.twig
@@ -1,9 +1,13 @@
-{% extends '@SyliusShop/shared/layout/base.html.twig' %}
+{% extends '@SyliusShop/checkout/common/layout.html.twig' %}
 
-{% set prefixes = ['flux_se_sylius_stripe_plugin.order_pay.stripe_web_elements.capture'] %}
+{% set prefixes = ['flux_se_sylius_stripe_plugin.order_pay.stripe_web_elements.capture', 'sylius_shop.checkout'] %}
 
-{% block title %}{{ 'flux_se_sylius_stripe_plugin.gateway_factory.stripe_web_elements'|trans }} | {{ parent() }}{% endblock %}
+{% block title %}
+	{{ 'flux_se_sylius_stripe_plugin.gateway_factory.stripe_web_elements'|trans }}
+	|
+	{{ parent() }}
+{% endblock %}
 
-{% block content %}
-    {% hook 'flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture' %}
+{% block body %}
+	{% hook 'flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.content' %}
 {% endblock %}

--- a/templates/shop/order_pay/web_elements/capture/content.html.twig
+++ b/templates/shop/order_pay/web_elements/capture/content.html.twig
@@ -1,0 +1,23 @@
+{% set prefixes = ['flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture', 'sylius_shop.checkout'] %}
+
+<div class="d-flex flex-column min-vh-100 overflow-hidden">
+	<div class="bg-white border-bottom py-4">
+		<div class="container">
+			<div class="row align-items-center">
+				{% hook 'common.header' with { _prefixes: prefixes, order } %}
+			</div>
+		</div>
+	</div>
+	<div class="flex-grow-1 d-flex align-items-stretch">
+		<div class="container">
+			<div class="row h-100">
+				<div class="col pt-4 pb-5">
+					{% hook 'form' with { _prefixes: prefixes } %}
+				</div>
+				<div class="col-12 col-lg-5 py-5 ps-lg-6 position-relative checkout-sidebar">
+					{% hook 'common.sidebar' with { _prefixes: prefixes, order } %}
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/shop/order_pay/web_elements/capture/form.html.twig
+++ b/templates/shop/order_pay/web_elements/capture/form.html.twig
@@ -5,34 +5,32 @@
 {% set action_url = hookable_metadata.context.action_url %}
 
 <div class="container my-auto">
-    <div class="row align-items-center justify-content-center vh-100">
-        <div class="col-12 col-md-6">
-            <h1>{{ 'sylius.ui.total'|trans }}: {{ money.format(model.amount, model.currency) }}</h1>
-        </div>
-        <div class="col-12 col-md-6">
-            <form id="payment-form">
-                <div id="payment-element"></div>
+	<div class="row align-items-center justify-content-center vh-100">
+		<div class="col-12 col-xl-8 mb-4">
+			<form id="payment-form">
+				<div id="payment-element"></div>
 
-                <div class="btn-list mt-3">
-                    <button type="submit" class="btn btn-primary" disabled>
-                        {{ 'flux_se_sylius_stripe_plugin.order_pay.web_elements.pay'|trans }}
-                    </button>
-                    <a class="btn" href="{{ action_url }}">{{ 'sylius.ui.cancel'|trans }}</a>
-                </div>
+				<div class="btn-list mt-3">
+					<button type="submit" class="btn btn-primary" disabled>
+						{{ 'flux_se_sylius_stripe_plugin.order_pay.web_elements.pay'|trans }}
+					</button>
+					<a class="btn" href="{{ action_url }}">{{ 'sylius.ui.cancel'|trans }}</a>
+				</div>
 
-                <div id="error-message" class="d-none alert alert-danger mt-3"></div>
-            </form>
+				<div id="error-message" class="d-none alert alert-danger mt-3"></div>
+			</form>
 
-            {% if app.debug %}
-                <p class="col mt-3 text-muted">
-                    Payment methods are dynamically displayed based on customer location, order amount, and currency.
-                    <a href="https://dashboard.stripe.com{{ model.livemode ? '' : '/test' }}/settings/payment_methods/review?transaction_id={{ model.id }}"
-                       target="_blank"
-                       rel="noopener noreferrer">
-                        Preview payment methods by transaction
-                    </a>
-                </p>
-            {% endif %}
-        </div>
-    </div>
+			{% if app.debug %}
+				<p class="col mt-3 text-muted">
+					Payment methods are dynamically displayed based on customer location, order amount, and currency.
+					<a href="https://dashboard.stripe.com{{ model.livemode ? '' : '/test' }}/settings/payment_methods/review?transaction_id={{ model.id }}" target="_blank" rel="noopener noreferrer">
+						Preview payment methods by transaction
+					</a>
+				</p>
+			{% endif %}
+		</div>
+		<div class="col-12 col-xl-4 ps-xl-5 mb-4 sticky-xl-top">
+			{% hook 'sidebar' %}
+		</div>
+	</div>
 </div>

--- a/templates/shop/order_pay/web_elements/capture/form.html.twig
+++ b/templates/shop/order_pay/web_elements/capture/form.html.twig
@@ -4,33 +4,24 @@
 {% set model = hookable_metadata.context.model %}
 {% set action_url = hookable_metadata.context.action_url %}
 
-<div class="container my-auto">
-	<div class="row align-items-center justify-content-center vh-100">
-		<div class="col-12 col-xl-8 mb-4">
-			<form id="payment-form">
-				<div id="payment-element"></div>
+<form id="payment-form">
+	<div id="payment-element"></div>
 
-				<div class="btn-list mt-3">
-					<button type="submit" class="btn btn-primary" disabled>
-						{{ 'flux_se_sylius_stripe_plugin.order_pay.web_elements.pay'|trans }}
-					</button>
-					<a class="btn" href="{{ action_url }}">{{ 'sylius.ui.cancel'|trans }}</a>
-				</div>
-
-				<div id="error-message" class="d-none alert alert-danger mt-3"></div>
-			</form>
-
-			{% if app.debug %}
-				<p class="col mt-3 text-muted">
-					Payment methods are dynamically displayed based on customer location, order amount, and currency.
-					<a href="https://dashboard.stripe.com{{ model.livemode ? '' : '/test' }}/settings/payment_methods/review?transaction_id={{ model.id }}" target="_blank" rel="noopener noreferrer">
-						Preview payment methods by transaction
-					</a>
-				</p>
-			{% endif %}
-		</div>
-		<div class="col-12 col-xl-4 ps-xl-5 mb-4 sticky-xl-top">
-			{% hook 'sidebar' %}
-		</div>
+	<div class="btn-list mt-3">
+		<button type="submit" class="btn btn-primary" disabled>
+			{{ 'flux_se_sylius_stripe_plugin.order_pay.web_elements.pay'|trans }}
+		</button>
+		<a class="btn" href="{{ action_url }}">{{ 'sylius.ui.cancel'|trans }}</a>
 	</div>
-</div>
+
+	<div id="error-message" class="d-none alert alert-danger mt-3"></div>
+</form>
+
+{% if app.debug %}
+	<p class="col mt-3 text-muted">
+		Payment methods are dynamically displayed based on customer location, order amount, and currency.
+		<a href="https://dashboard.stripe.com{{ model.livemode ? '' : '/test' }}/settings/payment_methods/review?transaction_id={{ model.id }}" target="_blank" rel="noopener noreferrer">
+			Preview payment methods by transaction
+		</a>
+	</p>
+{% endif %}


### PR DESCRIPTION
## 🚀 Feature: Order Summary Live Component for Stripe Web Elements

### 📌 Objective
This PR introduces a **Live Component** to display the order details next to the payment form when using **Stripe Web Elements**. This improves the **user experience** by allowing customers to review their order before completing the payment.

The idea is to reuse Sylius' CartSummary component along with its associated templates to ensure graphical consistency. The creation of the LiveComponent is necessary to handle the retrieval of the order using a custom logic via the PaymentRequest token.

### 📸 Screenshots:
![screencapture-localhost-8000-payment-request-pay-0194d19b-4bb8-7051-a5b9-0f8436657403-2025-02-04-16_36_50 (1)](https://github.com/user-attachments/assets/44be3696-2148-4364-8be0-2646faaacd8c)


### 🔧 Key Changes
- **Implemented a Live Component (`SummaryPaymentComponent`)**
  - Fetches the order from **Request Payment Security Token**
  - Dynamically updates order details without requiring a page reload
- **Configured `sylius_twig_hooks` to inject the Live Component**
  - Hook: `flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.sidebar`
- **Modified templates to integrate the new component**
  - Ensured seamless integration with **Stripe Web Elements**

### ✅ Testing Instructions
1. **Ensure you have Stripe Web Elements configured in your Sylius instance**
2. **Go to the checkout payment page**
3. **Verify that the order summary appears next to the payment form**
4. **Confirm that the summary updates correctly based on the order details**

### 🛠️ Technical Details
- The order is retrieved using **Request Payment Security Token**
- The component is registered dynamically via **CompilerPass**
- Template hook used: **`flux_se_sylius_stripe_plugin.shop.order_pay.web_elements.capture.sidebar`**
- Supports Sylius **2.0+**

### 🏗️ Task List
- [x] Implement the **Live Component**
- [x] Configure **Sylius Twig Hooks** for injection
- [x] Modify templates for integration
- [x] Ensure compatibility with **Stripe Web Elements**
- [x] Test with `bin/console debug:container | grep sylius_live_component`
- [ ] Add unit tests (if required)
- [ ] Gather feedback and apply necessary improvements

### 🔥 Notes
- This feature is **fully backward-compatible**
- Open to **feedback** and further improvements!

---
🔥 **Looking forward to your review!** 🚀
