### PR TITLE
[DOC]  Add Webhook documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,14 +11,9 @@
 /ecs.php export-ignore
 /etc export-ignore
 /features export-ignore
-/Makefile export-ignore
 /node_modules export-ignore
-/phpspec.yml.dist export-ignore
-/phpstan.neon export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
-/psalm.xml export-ignore
-/spec export-ignore
-/symfony.lock export-ignore
 /tests/Application export-ignore
 /tests/Api export-ignore
 /tests/DataFixtures export-ignore

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Payment method configuration edit form in the Sylius admin.
 > ⚠️ Using the command `stripe trigger checkout.session.completed` will always result in a `500 error`,
 > because the test object will not embed any usable metadata.
 
-## Advance documentation
+## Advanced documentation
 
 - [API (Sylius using APIPlatform)](docs/API.md)
 - [Webhook events](docs/WEBHOOK-EVENTS.md)

--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ Payment method configuration edit form in the Sylius admin.
 > ⚠️ Using the command `stripe trigger checkout.session.completed` will always result in a `500 error`,
 > because the test object will not embed any usable metadata.
 
-## API (Sylius Api Platform)
+## Advance documentation
 
-@todo
+- [API (Sylius using APIPlatform)](docs/API.md)
+- [Webhook events](docs/WEBHOOK-EVENTS.md)
 
 ## Changelog
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,3 @@
+# API (Sylius using APIPlatform)
+
+@todo

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Sylius Stripe Plugin Documentation
+
+## Installation & Configuration
+
+Read the main [README.md](../README.md) for installation and configuration instructions.
+
+## API (Sylius using APIPlatform)
+
+[Read the API documentation](API.md)
+
+## Webhook events
+
+[Read the Webhook events documentation](WEBHOOK-EVENTS.md)
+

--- a/docs/WEBHOOK-EVENTS.md
+++ b/docs/WEBHOOK-EVENTS.md
@@ -8,8 +8,7 @@ This plugin will be able to listen to webhook events which are related to a Syli
 If you want to listen to other events, you will have to create your own route and controller.
 However, you will be able to use services provided by this plugin to handle and verify the Stripe events.
 
-## How are webhook events listen using this plugin?
-
+## How are webhook events listened to using this plugin?
 Here is how the Sylius `PaymentRequest` notify process is working:
 
 1. Sylius provides a route named `sylius_payment_method_notify` which is used to listen to the Stripe events.

--- a/docs/WEBHOOK-EVENTS.md
+++ b/docs/WEBHOOK-EVENTS.md
@@ -15,7 +15,7 @@ Here is how the Sylius `PaymentRequest` notify process is working:
 1. Sylius provides a route named `sylius_payment_method_notify` which is used to listen to the Stripe events.
    This route needs a `code` parameter which is the payment method code. (ex:
    https://my-shop.tld/payment-methods/my_shop_stripe_checkout)
-2. This route is handle by a controller `sylius.controller.payment_method_notify`
+2. This route is handled by a controller `sylius.controller.payment_method_notify`
    this controller will:
    1. Try to find a related `Payment`. To do so, each `PaymentMethod` must implement a service with
       `\Sylius\Bundle\PaymentBundle\Provider\NotifyPaymentProviderInterface`.

--- a/docs/WEBHOOK-EVENTS.md
+++ b/docs/WEBHOOK-EVENTS.md
@@ -38,7 +38,7 @@ to the `PaymentRequest` `payload` under the `event` key.
 
 Finally, when the `NotifyPaymentRequest` command is handled, the `NotifyPaymentRequestHandler` will:
 
-1. Retrieve the Stripe `Event` from the Stripe API (to get a fresh one along with the underlying data objet).
+1. Retrieve the Stripe `Event` from the Stripe API (to get a fresh one along with the underlying data object).
 2. Send the Stripe `Event` and the `PaymentRequest` to the `WebhookEventProcessor` service.
    1. This service is simply getting the inner Stripe `Event` data object.
    2. Set this object to the `Payment` `details`. 

--- a/docs/WEBHOOK-EVENTS.md
+++ b/docs/WEBHOOK-EVENTS.md
@@ -1,0 +1,74 @@
+# Webhook events
+
+> Webhooks are triggered by Stripe on their server to your server.
+> If your server is into a private network, Stripe won't be allowed to reach your server.
+> Use the Stripe CLI to catch those webhook events. [Install Stripe CLI](https://stripe.com/docs/stripe-cli)
+
+This plugin will be able to listen to webhook events which are related to a Sylius payment only.
+If you want to listen to other events, you will have to create your own route and controller.
+However, you will be able to use services provided by this plugin to handle and verify the Stripe events.
+
+## How are webhook events listen using this plugin?
+
+Here is how the Sylius `PaymentRequest` notify process is working:
+
+1. Sylius provides a route named `sylius_payment_method_notify` which is used to listen to the Stripe events.
+   This route needs a `code` parameter which is the payment method code. (ex:
+   https://my-shop.tld/payment-methods/my_shop_stripe_checkout)
+2. This route is handle by a controller `sylius.controller.payment_method_notify`
+   this controller will:
+   1. Try to find a related `Payment`. To do so, each `PaymentMethod` must implement a service with
+      `\Sylius\Bundle\PaymentBundle\Provider\NotifyPaymentProviderInterface`.
+   2. Create a new `PaymentRequest` object with:
+      1. The related `Payment`.
+      2. The current `PaymentMethod`.
+      3. The `action` equal to `notify`.
+      4. The `payload` equal to the current `Request` content (normalized as an array).
+   3. A `Command` is dispatch to the `CommandBus` with this new `PaymentRequest` object.
+
+This plugin is hooking into the 2.i part of this process
+(see service: `FluxSE\SyliusStripePlugin\Provider\StripeNotifyPaymentProvider`) to:
+
+1. Get the current `Request` data.
+2. Validate the payload from Stripe (see service: `flux_se.sylius_stripe.stripe.resolver.event_resolver`).
+3. Extract the `data.object.metadata.token_hash` to retrieve the related `Payment`.
+
+It also hooks into the 2.ii.d part to add the Stripe `Event` as an array
+to the `PaymentRequest` `payload` under the `event` key.
+
+Finally, when the `NotifyPaymentRequest` command is handled, the `NotifyPaymentRequestHandler` will:
+
+1. Retrieve the Stripe `Event` from the Stripe API (to get a fresh one along with the underlying data objet).
+2. Send the Stripe `Event` and the `PaymentRequest` to the `WebhookEventProcessor` service.
+   1. This service is simply getting the inner Stripe `Event` data object.
+   2. Set this object to the `Payment` `details`. 
+3. Send the `PaymentRequest` to the `PaymentTransitionProcessor` service to transition the `Payment` state.
+
+## How to listen to `Payment related` Stripe events?
+
+When the event already contains a `data.object.metadata.token_hash` key and the value is an existing `PaymentRequest` hash.
+
+> If it's not the case, go to the next chapter [to listen to `NON Payment related` Stripe events](#how-to-listen-to-non-payment-related-stripe-events).
+
+Create a new class implementing the `FluxSE\SyliusStripePlugin\Processor\WebhookEventProcessorInterface` interface.
+Then declare a tagged service with tag name(s) among those:
+ - `flux_se.sylius_stripe.processor.webhook_event.checkout` for a "Stripe Checkout" related event.
+ - `flux_se.sylius_stripe.processor.webhook_event.web_elements` for a "Stripe Web Elements" related event.
+
+If needed, remember to update the `Payment` details with either a "Stripe Checkout Session" or a "Stripe Payment Intent" object
+depending on the factory you are targeting.
+
+## How to listen to `NON Payment related` Stripe events?
+
+At this point, you are free to do everything you want.
+You can create a new route and controller to listen to the NON `Payment` related Stripe events
+and finally create your own Webhook event handler.
+
+But you can also use the existing route and decorate the controller: `sylius.controller.payment_method_notify`
+to handle the NON `Payment` related Stripe events on the same URL.
+
+Using both cases, you will have to:
+
+1. Create a controller.
+2. Use `flux_se.sylius_stripe.stripe.resolver.event_resolver` to verify the Stripe sent payload contained in the `Request` content.
+3. Send a `Command` to the `CommandBus` with at least the Stripe `Event` id and the `PaymentMethod` code.


### PR DESCRIPTION
This pull request includes several documentation updates.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R149): Renamed the "API (Sylius Api Platform)" section to "Advance documentation" and added links to the API and Webhook events documentation.
* [`docs/API.md`](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R1-R3): Added a placeholder for the API documentation.
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R1-R14): Created a new documentation file for the Sylius Stripe Plugin, including installation, configuration, and links to detailed API and Webhook events documentation.
* [`docs/WEBHOOK-EVENTS.md`](diffhunk://#diff-df3e6145b43c3bd61021b5393565fd38a3f7d3980ff70b0ce15ce2de04fac80fR1-R74): Added comprehensive documentation on how to handle Stripe webhook events using the plugin, including detailed steps and code examples.