### PR TITLE
Do not rely on payment status in the Session transition provider let other mode detect it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,10 +250,11 @@ jobs:
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
 
-            -   name: Run non-JS Behat
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+            # Disabled no scenarios for now
+            #-   name: Run non-JS Behat
+            #    run: |
+            #        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+            #        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
 
             -   name: Run Behat (Panther)
                 run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,10 +245,22 @@ jobs:
                 name: Run PHPUnit
                 run: vendor/bin/phpunit --colors=always
 
-            -
-                name: Run Behat
-                run: vendor/bin/behat --colors --strict -vvv --no-interaction || vendor/bin/behat --colors --strict -vvv --no-interaction --rerun
+            -   name: Run non-UI Behat
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
 
+            -   name: Run non-JS Behat
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+
+            -   name: Run Behat (Panther)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+            
             -
                 name: Upload Behat logs
                 uses: actions/upload-artifact@v4

--- a/features/shop/stripe_checkout/paying.feature
+++ b/features/shop/stripe_checkout/paying.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Checkout Session during checkout
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_checkout/paying_using_authorize.feature
+++ b/features/shop/stripe_checkout/paying_using_authorize.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Checkout Session during checkout using authorized
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_checkout/paying_using_authorize_without_webhook.feature
+++ b/features/shop/stripe_checkout/paying_using_authorize_without_webhook.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Checkout Session during checkout without webhook usi
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_checkout/paying_without_webhook.feature
+++ b/features/shop/stripe_checkout/paying_without_webhook.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Checkout Session during checkout without webhook
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_web_elements/paying.feature
+++ b/features/shop/stripe_web_elements/paying.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Web Elements during checkout
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_web_elements/paying_using_authorize.feature
+++ b/features/shop/stripe_web_elements/paying_using_authorize.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Web Elements during checkout using authorized
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_web_elements/paying_using_authorize_without_webhook.feature
+++ b/features/shop/stripe_web_elements/paying_using_authorize_without_webhook.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Web Elements during checkout
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript

--- a/features/shop/stripe_web_elements/paying_without_webhook.feature
+++ b/features/shop/stripe_web_elements/paying_without_webhook.feature
@@ -11,7 +11,7 @@ Feature: Paying with Stripe Web Elements during checkout without webhook
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
         And I am a logged in customer
-        And I had product "PHP T-Shirt" in the cart
+        And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
     @ui @api @javascript
@@ -22,8 +22,7 @@ Feature: Paying with Stripe Web Elements during checkout without webhook
 
     @ui @api @javascript
     Scenario: Cancelling the payment without webhooks
-        Given I added product "PHP T-Shirt" to the cart
-        And I have proceeded selecting "Stripe" payment method
+        Given I have proceeded selecting "Stripe" payment method
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again

--- a/src/Provider/Transition/Checkout/PaymentModeTransitionProvider.php
+++ b/src/Provider/Transition/Checkout/PaymentModeTransitionProvider.php
@@ -22,7 +22,7 @@ final class PaymentModeTransitionProvider implements SessionModeTransitionProvid
     {
         $paymentIntent = $this->getPaymentIntent($session);
 
-        return $paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED;
+        return $paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED && Session::PAYMENT_STATUS_UNPAID !== $session->payment_status;
     }
 
     public function isFail(Session $session): bool
@@ -34,7 +34,7 @@ final class PaymentModeTransitionProvider implements SessionModeTransitionProvid
     {
         $paymentIntent = $this->getPaymentIntent($session);
 
-        return $paymentIntent->status === PaymentIntent::STATUS_PROCESSING;
+        return $paymentIntent->status === PaymentIntent::STATUS_PROCESSING && Session::PAYMENT_STATUS_UNPAID === $session->payment_status;
     }
 
     public function isCancel(Session $session): bool

--- a/src/Provider/Transition/Checkout/SessionTransitionProvider.php
+++ b/src/Provider/Transition/Checkout/SessionTransitionProvider.php
@@ -28,12 +28,16 @@ final class SessionTransitionProvider implements SessionTransitionProviderInterf
             return false;
         }
 
-        return Session::PAYMENT_STATUS_UNPAID !== $session->payment_status;
+        return $this->sessionModeTransitionProvider->isComplete($session);
     }
 
     public function isFail(Session $session): bool
     {
-        return Session::STATUS_EXPIRED === $session->status;
+        if (Session::STATUS_EXPIRED === $session->status) {
+            return true;
+        }
+
+        return $this->sessionModeTransitionProvider->isFail($session);
     }
 
     public function isProcess(Session $session): bool
@@ -42,7 +46,7 @@ final class SessionTransitionProvider implements SessionTransitionProviderInterf
             return false;
         }
 
-        return Session::PAYMENT_STATUS_UNPAID === $session->payment_status;
+        return $this->sessionModeTransitionProvider->isProcess($session);
     }
 
     public function isCancel(Session $session): bool


### PR DESCRIPTION
This pull request refines the logic for determining session states in the `PaymentModeTransitionProvider` and `SessionTransitionProvider` classes. The changes ensure better encapsulation by delegating state checks to the appropriate provider and introduce additional conditions for handling payment statuses.

### Updates to `PaymentModeTransitionProvider`:

* **Enhanced `isComplete` logic**: Added a condition to ensure the session's payment status is not `PAYMENT_STATUS_UNPAID` alongside checking the payment intent status. (`src/Provider/Transition/Checkout/PaymentModeTransitionProvider.php`, [src/Provider/Transition/Checkout/PaymentModeTransitionProvider.phpL25-R25](diffhunk://#diff-5f00b17dda1e39152f6c067f8f33d0b727d59d2817250485834da961f2b1cbe1L25-R25))
* **Enhanced `isProcess` logic**: Added a condition to confirm the session's payment status is `PAYMENT_STATUS_UNPAID` while verifying the payment intent status. (`src/Provider/Transition/Checkout/PaymentModeTransitionProvider.php`, [src/Provider/Transition/Checkout/PaymentModeTransitionProvider.phpL37-R37](diffhunk://#diff-5f00b17dda1e39152f6c067f8f33d0b727d59d2817250485834da961f2b1cbe1L37-R37))

### Updates to `SessionTransitionProvider`:

* **Delegation in `isComplete`**: Replaced direct session payment status checks with delegation to `sessionModeTransitionProvider` for determining completion state. (`src/Provider/Transition/Checkout/SessionTransitionProvider.php`, [src/Provider/Transition/Checkout/SessionTransitionProvider.phpL31-R40](diffhunk://#diff-c40e367667cb510a126870005b25daa17969d20a8810c9de5ca46e3ae861784dL31-R40))
* **Delegation and additional logic in `isFail`**: Added a condition to check for expired session status and delegated further failure state checks to `sessionModeTransitionProvider`. (`src/Provider/Transition/Checkout/SessionTransitionProvider.php`, [src/Provider/Transition/Checkout/SessionTransitionProvider.phpL31-R40](diffhunk://#diff-c40e367667cb510a126870005b25daa17969d20a8810c9de5ca46e3ae861784dL31-R40))
* **Delegation in `isProcess`**: Replaced direct session payment status checks with delegation to `sessionModeTransitionProvider` for determining processing state. (`src/Provider/Transition/Checkout/SessionTransitionProvider.php`, [src/Provider/Transition/Checkout/SessionTransitionProvider.phpL45-R49](diffhunk://#diff-c40e367667cb510a126870005b25daa17969d20a8810c9de5ca46e3ae861784dL45-R49))