### PR TITLE
Add expand params provider for WebElements retrieve manager

### DIFF
--- a/config/services/managers.yaml
+++ b/config/services/managers.yaml
@@ -45,6 +45,7 @@ services:
         class: FluxSE\SyliusStripePlugin\Manager\WebElements\RetrieveManager
         arguments:
             - '@flux_se.sylius_stripe.stripe.factory.client'
+            - '@flux_se.sylius_stripe.provider.web_elements.retrieve.params'
     FluxSE\SyliusStripePlugin\Manager\WebElements\RetrieveManagerInterface:
         alias: flux_se.sylius_stripe.manager.web_elements.retrieve
 

--- a/config/services/providers/web_elements/retrieve_params_providers.yaml
+++ b/config/services/providers/web_elements/retrieve_params_providers.yaml
@@ -1,0 +1,18 @@
+parameters:
+    flux_se.sylius_stripe.web_elements.retrieve.expand_fields:
+        - 'latest_charge'
+
+services:
+
+    flux_se.sylius_stripe.provider.web_elements.retrieve.params:
+        class: FluxSE\SyliusStripePlugin\Provider\CompositeParamsProvider
+        arguments:
+            - !tagged_iterator flux_se.sylius_stripe.provider.web_elements.retrieve.inner_params
+
+    flux_se.sylius_stripe.provider.web_elements.retrieve.expand:
+        class: FluxSE\SyliusStripePlugin\Provider\ExpandProvider
+        arguments:
+            - '%flux_se.sylius_stripe.web_elements.retrieve.expand_fields%'
+        tags:
+            - name: flux_se.sylius_stripe.provider.web_elements.retrieve.inner_params
+              priority: -100


### PR DESCRIPTION
## Summary

This PR fixes the issue reported in #21 where the `PaymentIntentTransitionProvider::isChargeRefunded()` method throws a `LogicException` because `latest_charge` is not expanded when retrieving the PaymentIntent via WebElements.

## Changes

- Added `config/services/providers/web_elements/retrieve_params_providers.yaml` with expand configuration for `latest_charge`
- Updated `config/services/managers.yaml` to inject the params provider into `flux_se.sylius_stripe.manager.web_elements.retrieve`

## Root Cause

The Checkout `RetrieveManager` was correctly configured with a params provider that expands `payment_intent.latest_charge`, but the WebElements `RetrieveManager` was missing this configuration entirely.

## Testing

Verified locally that the fix resolves the `LogicException` and payments complete successfully.

Fixes #21