### PR TITLE
[Subscription] add missing expanded object

### DIFF
--- a/config/services/providers/checkout/retrieve_params_providers.yaml
+++ b/config/services/providers/checkout/retrieve_params_providers.yaml
@@ -7,7 +7,9 @@ parameters:
         - 'payment_intent.payment_method'
         - 'invoice'
         - 'invoice.charge'
-        - 'invoice.payment_intent'
+        - 'invoice.payment_intent' # subscription mode
+        - 'invoice.payment_intent.latest_charge' # subscription mode
+        - 'invoice.payment_intent.payment_method' # subscription mode
         - 'invoice.default_payment_method'
         - 'invoice.discounts'
         - 'setup_intent'

--- a/src/Provider/Transition/WebElements/PaymentIntentTransitionProvider.php
+++ b/src/Provider/Transition/WebElements/PaymentIntentTransitionProvider.php
@@ -70,7 +70,9 @@ final class PaymentIntentTransitionProvider implements PaymentIntentTransitionPr
         if (false === $charge instanceof Charge) {
             throw new \LogicException(sprintf(
                 'To avoid too many API requests, we need to get access to the PaymentIntent->latest_charge object at this point.
-                Please check that "%s" is expanding the Checkout/Session retrieval request with "payment_intent.latest_charge".',
+                Please check that "%s" is expanding the Checkout/Session retrieval request with
+                "payment_intent.latest_charge" (mode payment)
+                or "invoice.payment_intent.latest_charge" (mode subscription).',
                 ExpandProvider::class,
             ));
         }


### PR DESCRIPTION
This pull request updates the way we retrieve and handle expanded fields for Stripe Checkout Sessions, particularly to improve support for subscription mode. The changes ensure that the necessary nested objects are available for downstream logic, and clarify error messaging for developers.

**Improvements for subscription mode support:**

* Added `invoice.payment_intent.latest_charge` and `invoice.payment_intent.payment_method` to the list of expanded fields in `retrieve_params_providers.yaml`, ensuring these nested objects are available when handling subscriptions.

**Developer experience and error handling:**

* Updated the error message in `PaymentIntentTransitionProvider.php` to instruct developers to expand either `payment_intent.latest_charge` (for payment mode) or `invoice.payment_intent.latest_charge` (for subscription mode), making the requirements clearer and reducing confusion.