### PR TITLE
[Behat] Fix flaky API authorize scenarios + reorganize order of tags in scenarios

### DIFF
--- a/features/admin/stripe_checkout/cancel_authorized_order.feature
+++ b/features/admin/stripe_checkout/cancel_authorized_order.feature
@@ -15,7 +15,7 @@ Feature: Canceling an authorized order with Stripe Checkout
         And this order is already authorized using Stripe Checkout
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Cancelling the order with an authorized payment
         Given I am viewing the summary of this order
         And I am prepared to cancel authorization on this order

--- a/features/admin/stripe_checkout/cancel_order.feature
+++ b/features/admin/stripe_checkout/cancel_order.feature
@@ -15,7 +15,7 @@ Feature: Canceling an order with Stripe Checkout
         And this order is not yet paid using Stripe Checkout
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Cancelling the order when a checkout session is still available
         Given I am viewing the summary of this order
         And I am prepared to expire this order
@@ -24,7 +24,7 @@ Feature: Canceling an order with Stripe Checkout
         And it should have payment with state cancelled
         And it should have payment state "Cancelled"
 
-    @ui @api
+    @api @ui
     Scenario: Cancelling the order after the customer canceled the payment
         Given I am viewing the summary of this order
         And I am prepared to expire this order

--- a/features/admin/stripe_checkout/capture_authorization_order.feature
+++ b/features/admin/stripe_checkout/capture_authorization_order.feature
@@ -15,7 +15,7 @@ Feature: Capturing the authorization of an order with Stripe Checkout Session
         And this order is already authorized using Stripe Checkout
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Capture the Stripe authorized payment
         Given I am viewing the summary of this order
         And I am prepared to capture authorization of this order

--- a/features/admin/stripe_checkout/refunding_order.feature
+++ b/features/admin/stripe_checkout/refunding_order.feature
@@ -14,7 +14,7 @@ Feature: Refunding an order with Stripe Checkout Session
         And the customer chose "Free" shipping method to "United States" with "Stripe" payment
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Initializing the Stripe refund for a Stripe Checkout Session mode payment
         Given this order is already paid using Stripe Checkout
         And I am viewing the summary of this order
@@ -24,7 +24,7 @@ Feature: Refunding an order with Stripe Checkout Session
         And it should have payment with state refunded
         And it should have payment state "Refunded"
 
-    @ui @api
+    @api @ui
     Scenario: Initializing the Stripe refund for a Stripe Checkout Session mode subscription
         Given this order related to a subscription is already paid using Stripe Checkout
         And I am viewing the summary of this order

--- a/features/admin/stripe_web_elements/cancel_authorized_order.feature
+++ b/features/admin/stripe_web_elements/cancel_authorized_order.feature
@@ -15,7 +15,7 @@ Feature: Canceling an authorized order with Stripe JS
         And this order is already authorized using Stripe web elements
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Cancelling the order with an authorized payment
         Given I am viewing the summary of this order
         And I am prepared to cancel authorization on this order

--- a/features/admin/stripe_web_elements/cancel_order.feature
+++ b/features/admin/stripe_web_elements/cancel_order.feature
@@ -15,7 +15,7 @@ Feature: Canceling an order with Stripe JS
         And this order is not yet paid using Stripe web elements
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Cancelling the order when a payment intent is still available
         Given I am viewing the summary of this order
         And I am prepared to cancel this order

--- a/features/admin/stripe_web_elements/capture_authorization_order.feature
+++ b/features/admin/stripe_web_elements/capture_authorization_order.feature
@@ -15,7 +15,7 @@ Feature: Capturing the authorization of an order with Stripe JS
         And this order is already authorized using Stripe web elements
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Initializing the Stripe refund
         Given I am viewing the summary of this order
         And I am prepared to capture authorization of this order

--- a/features/admin/stripe_web_elements/refunding_order.feature
+++ b/features/admin/stripe_web_elements/refunding_order.feature
@@ -15,7 +15,7 @@ Feature: Refunding an order with Stripe JS
         And this order is already paid using Stripe web elements
         And I am logged in as an administrator
 
-    @ui @api
+    @api @ui
     Scenario: Initializing the Stripe refund
         Given I am viewing the summary of this order
         And I am prepared to refund this order

--- a/features/shop/stripe_checkout/paying.feature
+++ b/features/shop/stripe_checkout/paying.feature
@@ -14,19 +14,19 @@ Feature: Paying with Stripe Checkout Session during checkout
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe
         When I confirm my order with Stripe payment
         And I complete my Stripe payment successfully
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment
@@ -34,7 +34,7 @@ Feature: Paying with Stripe Checkout Session during checkout
         And I complete my Stripe payment successfully
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_checkout/paying_using_authorize.feature
+++ b/features/shop/stripe_checkout/paying_using_authorize.feature
@@ -14,20 +14,20 @@ Feature: Paying with Stripe Checkout Session during checkout using authorized
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe using authorize
         When I confirm my order with Stripe payment using authorize
         And I complete my Stripe payment successfully using authorize
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment using authorize
         When I confirm my order with Stripe payment using authorize
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success using authorize
         Given I have confirmed my order with Stripe payment using authorize
         But I have clicked on "go back" during my Stripe payment
@@ -36,7 +36,7 @@ Feature: Paying with Stripe Checkout Session during checkout using authorized
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing using authorize
         Given I have confirmed my order with Stripe payment using authorize
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_checkout/paying_using_authorize_without_webhook.feature
+++ b/features/shop/stripe_checkout/paying_using_authorize_without_webhook.feature
@@ -14,20 +14,20 @@ Feature: Paying with Stripe Checkout Session during checkout without webhook usi
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe without webhooks using authorize
         When I confirm my order with Stripe payment using authorize
         And I complete my Stripe payment successfully without webhook using authorize
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment without webhooks using authorize
         When I confirm my order with Stripe payment using authorize
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success without webhooks using authorize
         Given I have confirmed my order with Stripe payment using authorize
         But I have clicked on "go back" during my Stripe payment
@@ -36,7 +36,7 @@ Feature: Paying with Stripe Checkout Session during checkout without webhook usi
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing without webhooks using authorize
         Given I have confirmed my order with Stripe payment using authorize
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_checkout/paying_without_webhook.feature
+++ b/features/shop/stripe_checkout/paying_without_webhook.feature
@@ -14,19 +14,19 @@ Feature: Paying with Stripe Checkout Session during checkout without webhook
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe without webhooks
         When I confirm my order with Stripe payment
         And I complete my Stripe payment successfully without webhook
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment without webhooks
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success without webhooks
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment
@@ -34,7 +34,7 @@ Feature: Paying with Stripe Checkout Session during checkout without webhook
         And I complete my Stripe payment successfully without webhook
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing without webhooks
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_web_elements/paying.feature
+++ b/features/shop/stripe_web_elements/paying.feature
@@ -14,19 +14,19 @@ Feature: Paying with Stripe Web Elements during checkout
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe
         When I confirm my order with Stripe payment
         And I complete my Stripe payment successfully
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment
@@ -34,7 +34,7 @@ Feature: Paying with Stripe Web Elements during checkout
         And I complete my Stripe payment successfully
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_web_elements/paying_using_authorize.feature
+++ b/features/shop/stripe_web_elements/paying_using_authorize.feature
@@ -14,20 +14,20 @@ Feature: Paying with Stripe Web Elements during checkout using authorized
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe using authorize
         When I confirm my order with Stripe payment
         And I complete my Stripe payment successfully using authorize
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment using authorize
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success using authorize
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment
@@ -36,7 +36,7 @@ Feature: Paying with Stripe Web Elements during checkout using authorized
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing using authorize
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_web_elements/paying_using_authorize_without_webhook.feature
+++ b/features/shop/stripe_web_elements/paying_using_authorize_without_webhook.feature
@@ -14,20 +14,20 @@ Feature: Paying with Stripe Web Elements during checkout
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe without webhooks using authorize
         When I confirm my order with Stripe payment
         And I complete my Stripe payment successfully without webhook using authorize
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment without webhooks using authorize
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success without webhooks using authorize
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment
@@ -36,7 +36,7 @@ Feature: Paying with Stripe Web Elements during checkout
         Then I should be notified that my payment has been authorized
         And I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing without webhooks using authorize
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment

--- a/features/shop/stripe_web_elements/paying_without_webhook.feature
+++ b/features/shop/stripe_web_elements/paying_without_webhook.feature
@@ -14,20 +14,20 @@ Feature: Paying with Stripe Web Elements during checkout without webhook
         And I have product "PHP T-Shirt" added to the cart
         And I have proceeded selecting "Stripe" payment method
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Successful payment in Stripe without webhooks
         When I confirm my order with Stripe payment
         And I complete my Stripe payment successfully without webhook
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Cancelling the payment without webhooks
         Given I have proceeded selecting "Stripe" payment method
         When I confirm my order with Stripe payment
         And I click on "go back" during my Stripe payment
         Then I should be able to pay again
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment with success without webhooks
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment
@@ -35,7 +35,7 @@ Feature: Paying with Stripe Web Elements during checkout without webhook
         And I complete my Stripe payment successfully without webhook
         Then I should see the thank you page
 
-    @ui @api @javascript
+    @api @ui @javascript
     Scenario: Retrying the payment and failing without webhooks
         Given I have confirmed my order with Stripe payment
         But I have clicked on "go back" during my Stripe payment

--- a/tests/Behat/Context/Api/Shop/StripeCheckoutContext.php
+++ b/tests/Behat/Context/Api/Shop/StripeCheckoutContext.php
@@ -10,6 +10,7 @@ use Stripe\Checkout\Session;
 use Stripe\Event;
 use Stripe\PaymentIntent;
 use Sylius\Behat\Client\ApiClientInterface;
+use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Shop\CheckoutContext;
 use Sylius\Behat\Context\Api\Shop\PaymentRequestContext;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -30,6 +31,7 @@ class StripeCheckoutContext extends MinkContext implements StripeContextInterfac
         private StripeCheckoutMocker $stripeCheckoutSessionMocker,
         private StripePage $stripePage,
         private ApiClientInterface $client,
+        private ResponseCheckerInterface $responseChecker,
     ) {
     }
 
@@ -136,18 +138,20 @@ class StripeCheckoutContext extends MinkContext implements StripeContextInterfac
         $paymentMethod = $order->getLastPayment()?->getMethod();
         Assert::notNull($paymentMethod);
 
-        $this->paymentRequestContext->aPaymentRequestWithActionForPaymentMethodShouldHaveState(
-            PaymentRequestInterface::ACTION_AUTHORIZE,
-            $paymentMethod,
-            PaymentRequestInterface::STATE_COMPLETED,
-        );
+        /** @var string $paymentRequestUri */
+        $paymentRequestUri = $this->sharedStorage->get('payment_request_uri');
+        $response = $this->client->customAction($paymentRequestUri, 'GET');
+
+        Assert::same($this->responseChecker->getValue($response, 'action'), PaymentRequestInterface::ACTION_AUTHORIZE);
+        Assert::contains($this->responseChecker->getValue($response, 'method'), (string) $paymentMethod->getCode());
+        Assert::same($this->responseChecker->getValue($response, 'state'), PaymentRequestInterface::STATE_COMPLETED);
     }
 
     protected function setupNotify(string $status, string $captureMethod): void
     {
-        $this->iTryToPayAgainWithStripePayment();
-
-        $paymentRequest = $this->stripePage->findLatestPaymentRequest();
+        /** @var string $paymentRequestUri */
+        $paymentRequestUri = $this->sharedStorage->get('payment_request_uri');
+        $paymentRequestHash = basename($paymentRequestUri);
 
         $paymentIntentId = 'pi_test_1';
         $checkoutSessionData = [
@@ -158,7 +162,7 @@ class StripeCheckoutContext extends MinkContext implements StripeContextInterfac
             'status' => Session::STATUS_COMPLETE,
             'payment_status' => Session::PAYMENT_STATUS_PAID,
             'metadata' => [
-                MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME => $paymentRequest->getId(),
+                MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME => $paymentRequestHash,
             ],
         ];
         $jsonEvent = [

--- a/tests/Behat/Page/External/StripePage.php
+++ b/tests/Behat/Page/External/StripePage.php
@@ -108,6 +108,9 @@ final class StripePage extends Page implements StripePageInterface
 
     public function findLatestPaymentRequest(): PaymentRequestInterface
     {
+        // Allow to wait for PaymentRequest to be processed
+        sleep(2);
+
         $paymentRequests = $this->paymentRequestRepository->findBy(
             [
                 'state' => [

--- a/tests/Behat/Page/External/StripePage.php
+++ b/tests/Behat/Page/External/StripePage.php
@@ -108,17 +108,14 @@ final class StripePage extends Page implements StripePageInterface
 
     public function findLatestPaymentRequest(): PaymentRequestInterface
     {
-        // Allow to wait for PaymentRequest to be processed
-        sleep(2);
-
         $paymentRequests = $this->paymentRequestRepository->findBy(
             [
                 'state' => [
                     PaymentRequestInterface::STATE_PROCESSING,
                 ],
                 'action' => [
-                        PaymentRequestInterface::ACTION_CAPTURE,
-                        PaymentRequestInterface::ACTION_AUTHORIZE,
+                    PaymentRequestInterface::ACTION_CAPTURE,
+                    PaymentRequestInterface::ACTION_AUTHORIZE,
                 ],
             ],
             [

--- a/tests/Behat/Resources/services/contexts.xml
+++ b/tests/Behat/Resources/services/contexts.xml
@@ -75,6 +75,7 @@
             <argument type="service" id="Tests\FluxSE\SyliusStripePlugin\Behat\Mocker\StripeCheckoutMocker"/>
             <argument type="service" id="tests.flux_se.sylius_stripe_plugin.behat.page.external.stripe_checkout_session"/>
             <argument type="service" id="sylius.behat.api_platform_client.shop"/>
+            <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface"/>
         </service>
 
         <service id="tests.flux_se.sylius_stripe_plugin.behat.context.api.shop.stripe_web_elements"


### PR DESCRIPTION
  ## Fix

  - `StripeCheckoutContext::setupNotify()` — drop the redundant `iTryToPayAgainWithStripePayment()` call; build `token_hash` from the existing `payment_request_uri` in `SharedStorage` (deterministic: always the latest created PR).
  - `StripeCheckoutContext::iShouldBeNotifiedThatMyPaymentHasBeenAuthorized()` — assert directly against the PR at `payment_request_uri` via a GET, instead of relying on core's non-deterministic `findOneBy()`. Inject `ResponseCheckerInterface`.