### PR TITLE
[Metadata] Enrich PaymentIntent with order-level data for Radar rules

### DIFF
--- a/config/services/providers/checkout/create_params_providers.yaml
+++ b/config/services/providers/checkout/create_params_providers.yaml
@@ -64,6 +64,34 @@ services:
             - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data
               priority: -100
 
+    flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata:
+        class: FluxSE\SyliusStripePlugin\Provider\CompositeMetadataParamsProvider
+        arguments:
+            - !tagged_iterator flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata
+        tags:
+            - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data
+              priority: -200
+
+    flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata.order:
+        class: FluxSE\SyliusStripePlugin\Provider\OrderMetadataProvider
+        tags:
+            - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata
+              priority: -100
+
+    flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata.product_categories:
+        class: FluxSE\SyliusStripePlugin\Provider\ProductCategoriesMetadataProvider
+        tags:
+            - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata
+              priority: -150
+
+    flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata.first_order_flag:
+        class: FluxSE\SyliusStripePlugin\Provider\FirstOrderFlagMetadataProvider
+        arguments:
+            - '@sylius.repository.order'
+        tags:
+            - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata
+              priority: -200
+
     flux_se.sylius_stripe.provider.checkout.create.line_items:
         class: FluxSE\SyliusStripePlugin\Provider\Checkout\Create\LineItemsProvider
         arguments:

--- a/config/services/providers/web_elements/create_params_providers.yaml
+++ b/config/services/providers/web_elements/create_params_providers.yaml
@@ -42,3 +42,23 @@ services:
         tags:
             - name: flux_se.sylius_stripe.provider.web_elements.create.metadata
               priority: -100
+
+    flux_se.sylius_stripe.provider.web_elements.create.metadata.order:
+        class: FluxSE\SyliusStripePlugin\Provider\OrderMetadataProvider
+        tags:
+            - name: flux_se.sylius_stripe.provider.web_elements.create.metadata
+              priority: -200
+
+    flux_se.sylius_stripe.provider.web_elements.create.metadata.product_categories:
+        class: FluxSE\SyliusStripePlugin\Provider\ProductCategoriesMetadataProvider
+        tags:
+            - name: flux_se.sylius_stripe.provider.web_elements.create.metadata
+              priority: -250
+
+    flux_se.sylius_stripe.provider.web_elements.create.metadata.first_order_flag:
+        class: FluxSE\SyliusStripePlugin\Provider\FirstOrderFlagMetadataProvider
+        arguments:
+            - '@sylius.repository.order'
+        tags:
+            - name: flux_se.sylius_stripe.provider.web_elements.create.metadata
+              priority: -300

--- a/src/Provider/FirstOrderFlagMetadataProvider.php
+++ b/src/Provider/FirstOrderFlagMetadataProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Provider;
+
+use Stripe\ApiResource;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+/**
+ * @template T as ApiResource
+ * @implements InnerParamsProviderInterface<T>
+ */
+final readonly class FirstOrderFlagMetadataProvider implements InnerParamsProviderInterface
+{
+    /** @param OrderRepositoryInterface<OrderInterface> $orderRepository */
+    public function __construct(
+        private OrderRepositoryInterface $orderRepository,
+    ) {
+    }
+
+    public function provide(PaymentRequestInterface $paymentRequest, array &$params): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $paymentRequest->getPayment();
+        $order = $payment->getOrder();
+        if (null === $order) {
+            return;
+        }
+
+        /** @var CustomerInterface|null $customer */
+        $customer = $order->getCustomer();
+        if (null === $customer) {
+            return;
+        }
+
+        $params['first_order'] = 1 === $this->orderRepository->countByCustomer($customer) ? 'yes' : 'no';
+    }
+}

--- a/src/Provider/OrderMetadataProvider.php
+++ b/src/Provider/OrderMetadataProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Provider;
+
+use Stripe\ApiResource;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+/**
+ * @template T as ApiResource
+ * @implements InnerParamsProviderInterface<T>
+ */
+final readonly class OrderMetadataProvider implements InnerParamsProviderInterface
+{
+    public function provide(PaymentRequestInterface $paymentRequest, array &$params): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $paymentRequest->getPayment();
+        $order = $payment->getOrder();
+        if (null === $order) {
+            return;
+        }
+
+        $number = $order->getNumber();
+        if (null !== $number) {
+            $params['order_number'] = $number;
+        }
+
+        // Stripe metadata values must be strings; total is expressed in minor units (e.g. cents).
+        $params['order_total'] = (string) $order->getTotal();
+
+        $currency = $order->getCurrencyCode();
+        if (null !== $currency) {
+            $params['currency'] = $currency;
+        }
+
+        $locale = $order->getLocaleCode();
+        if (null !== $locale) {
+            $params['locale'] = $locale;
+        }
+    }
+}

--- a/src/Provider/ProductCategoriesMetadataProvider.php
+++ b/src/Provider/ProductCategoriesMetadataProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Provider;
+
+use Stripe\ApiResource;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+/**
+ * @template T as ApiResource
+ * @implements InnerParamsProviderInterface<T>
+ */
+final readonly class ProductCategoriesMetadataProvider implements InnerParamsProviderInterface
+{
+    private const CATEGORIES_CAP = 10;
+
+    public function provide(PaymentRequestInterface $paymentRequest, array &$params): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $paymentRequest->getPayment();
+        $order = $payment->getOrder();
+        if (null === $order) {
+            return;
+        }
+
+        $codes = [];
+        foreach ($order->getItems() as $item) {
+            $code = $item->getProduct()?->getMainTaxon()?->getCode();
+            if (null === $code) {
+                continue;
+            }
+            $codes[strtolower($code)] = true;
+            if (count($codes) >= self::CATEGORIES_CAP) {
+                break;
+            }
+        }
+
+        if ([] === $codes) {
+            return;
+        }
+
+        $params['product_categories'] = implode(',', array_keys($codes));
+    }
+}

--- a/tests/Functional/DataFixtures/ORM/channel.yaml
+++ b/tests/Functional/DataFixtures/ORM/channel.yaml
@@ -70,3 +70,7 @@ Sylius\Component\Locale\Model\Locale:
 Sylius\Component\Core\Model\Taxon:
     menu_taxon:
         code: "MENU"
+    mugs_taxon:
+        code: "MUGS"
+    tea_taxon:
+        code: "TEA"

--- a/tests/Functional/DataFixtures/ORM/order_awaiting_payment.yaml
+++ b/tests/Functional/DataFixtures/ORM/order_awaiting_payment.yaml
@@ -6,6 +6,7 @@ Sylius\Component\Core\Model\Order:
         state: "new"
         paymentState: "awaiting_payment"
         shippingState: "ready"
+        number: "000000001"
         tokenValue: "token"
         customer: "@customer_oliver"
         billingAddress: "@address"
@@ -18,7 +19,7 @@ Sylius\Component\Core\Model\OrderItem:
         variant: "@product_variant"
         order: "@order"
     order_item_2:
-        variant: "@product_variant_free"
+        variant: "@product_variant_tea"
         order: "@order"
 
 Sylius\Component\Core\Model\OrderItemUnit:

--- a/tests/Functional/DataFixtures/ORM/product_variant.yaml
+++ b/tests/Functional/DataFixtures/ORM/product_variant.yaml
@@ -3,6 +3,12 @@ Sylius\Component\Core\Model\Product:
         fallbackLocale: en_US
         currentLocale: en
         code: 'MUG_SW'
+        mainTaxon: '@mugs_taxon'
+    product_tea:
+        fallbackLocale: en_US
+        currentLocale: en
+        code: 'TEA_SW'
+        mainTaxon: '@tea_taxon'
 
 Sylius\Component\Core\Model\ProductVariant:
     product_variant:
@@ -42,7 +48,15 @@ Sylius\Component\Core\Model\ProductVariant:
         position: 3
         channelPricings:
             channel_web: '@product_variant_free_channel_web_pricing'
-    
+    product_variant_tea:
+        code: 'TEA'
+        product: '@product_tea'
+        fallbackLocale: en_US
+        currentLocale: en
+        position: 1
+        channelPricings:
+            channel_web: '@product_variant_tea_channel_web_pricing'
+
 Sylius\Component\Core\Model\ProductTranslation:
     product_translation_mug_en_US:
         locale: 'en_US'
@@ -53,6 +67,11 @@ Sylius\Component\Core\Model\ProductTranslation:
         shortDescription: 'Short mug description'
         metaKeywords: 'mug'
         metaDescription: 'Mug description'
+    product_translation_tea_en_US:
+        locale: 'en_US'
+        translatable: '@product_tea'
+        slug: 'tea'
+        name: 'Tea'
 
 Sylius\Component\Product\Model\ProductVariantTranslation:
     product_variant_translation:
@@ -63,6 +82,10 @@ Sylius\Component\Product\Model\ProductVariantTranslation:
         name: 'Mug 2'
         locale: en_US
         translatable: '@product_variant_2'
+    product_variant_tea_translation:
+        name: 'Tea'
+        locale: en_US
+        translatable: '@product_variant_tea'
 
 Sylius\Component\Core\Model\ChannelPricing:
     product_variant_channel_web_pricing:
@@ -72,6 +95,9 @@ Sylius\Component\Core\Model\ChannelPricing:
         channelCode: 'WEB'
         price: 3000
     product_variant_free_channel_web_pricing:
+        channelCode: 'WEB'
+        price: 0
+    product_variant_tea_channel_web_pricing:
         channelCode: 'WEB'
         price: 0
 

--- a/tests/Functional/Provider/Checkout/Create/DetailsProviderTest.php
+++ b/tests/Functional/Provider/Checkout/Create/DetailsProviderTest.php
@@ -122,6 +122,15 @@ class DetailsProviderTest extends KernelTestCase
      */
     public static function getPaymentRequestAndExpectedDetails(): iterable
     {
+        $orderMetadata = [
+            'order_number' => '000000001',
+            'order_total' => '1500',
+            'currency' => 'USD',
+            'locale' => 'en_US',
+            'product_categories' => 'mugs,tea',
+            'first_order' => 'yes',
+        ];
+
         $expected = [
             'customer_email' => 'oliver@doe.com',
             'line_items' => [
@@ -143,7 +152,7 @@ class DetailsProviderTest extends KernelTestCase
                         'unit_amount' => 0,
                         'currency' => 'USD',
                         'product_data' => [
-                            'name' => '1x - Mug',
+                            'name' => '1x - Tea',
                             'images' => [
                                 'https://placehold.co/300',
                             ],
@@ -165,6 +174,9 @@ class DetailsProviderTest extends KernelTestCase
             'mode' => 'payment',
             'success_url' => 'https://myshop.tld/target-path',
             'cancel_url' => 'https://myshop.tld/after-path',
+            'payment_intent_data' => [
+                'metadata' => $orderMetadata,
+            ],
             'metadata' => [
                 'token_hash' => '',
             ],
@@ -188,6 +200,7 @@ class DetailsProviderTest extends KernelTestCase
             array_merge($expected, [
                 'payment_intent_data' => [
                     'capture_method' => 'manual',
+                    'metadata' => $orderMetadata,
                 ],
             ]),
         ];
@@ -199,6 +212,7 @@ class DetailsProviderTest extends KernelTestCase
                 'cancel_url' => 'https://myshop.tld/after-path',
                 'payment_intent_data' => [
                     'capture_method' => 'manual',
+                    'metadata' => $orderMetadata,
                 ],
             ]),
         ];

--- a/tests/Functional/Provider/WebElements/Create/DetailsProviderTest.php
+++ b/tests/Functional/Provider/WebElements/Create/DetailsProviderTest.php
@@ -99,6 +99,12 @@ class DetailsProviderTest extends KernelTestCase
             'currency' => 'USD',
             'metadata' => [
                 'token_hash' => '',
+                'order_number' => '000000001',
+                'order_total' => '1500',
+                'currency' => 'USD',
+                'locale' => 'en_US',
+                'product_categories' => 'mugs,tea',
+                'first_order' => 'yes',
             ],
         ];
 

--- a/tests/Unit/Provider/FirstOrderFlagMetadataProviderTest.php
+++ b/tests/Unit/Provider/FirstOrderFlagMetadataProviderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Provider;
+
+use FluxSE\SyliusStripePlugin\Provider\FirstOrderFlagMetadataProvider;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class FirstOrderFlagMetadataProviderTest extends TestCase
+{
+    public function test_it_marks_first_order_when_customer_has_one_order(): void
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $orderRepository->method('countByCustomer')->with($customer)->willReturn(1);
+
+        $provider = new FirstOrderFlagMetadataProvider($orderRepository);
+
+        $params = [];
+        $provider->provide($this->wrap($customer), $params);
+
+        self::assertSame(['first_order' => 'yes'], $params);
+    }
+
+    public function test_it_marks_returning_customer_when_count_is_greater_than_one(): void
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $orderRepository->method('countByCustomer')->with($customer)->willReturn(7);
+
+        $provider = new FirstOrderFlagMetadataProvider($orderRepository);
+
+        $params = [];
+        $provider->provide($this->wrap($customer), $params);
+
+        self::assertSame(['first_order' => 'no'], $params);
+    }
+
+    public function test_it_omits_key_for_guest_checkout(): void
+    {
+        $orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $orderRepository->expects(self::never())->method('countByCustomer');
+
+        $provider = new FirstOrderFlagMetadataProvider($orderRepository);
+
+        $params = [];
+        $provider->provide($this->wrap(null), $params);
+
+        self::assertSame([], $params);
+    }
+
+    public function test_it_returns_early_when_order_is_null(): void
+    {
+        $orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $orderRepository->expects(self::never())->method('countByCustomer');
+
+        $provider = new FirstOrderFlagMetadataProvider($orderRepository);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn(null);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $params = ['untouched' => true];
+        $provider->provide($paymentRequest, $params);
+
+        self::assertSame(['untouched' => true], $params);
+    }
+
+    private function wrap(?CustomerInterface $customer): PaymentRequestInterface
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCustomer')->willReturn($customer);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        return $paymentRequest;
+    }
+}

--- a/tests/Unit/Provider/OrderMetadataProviderTest.php
+++ b/tests/Unit/Provider/OrderMetadataProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Provider;
+
+use FluxSE\SyliusStripePlugin\Provider\OrderMetadataProvider;
+use PHPUnit\Framework\TestCase;
+use Stripe\PaymentIntent;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class OrderMetadataProviderTest extends TestCase
+{
+    /** @var OrderMetadataProvider<PaymentIntent> */
+    private OrderMetadataProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new OrderMetadataProvider();
+    }
+
+    public function test_it_populates_all_keys_when_order_is_complete(): void
+    {
+        $paymentRequest = $this->wrapOrder(
+            number: '000000042',
+            total: 4250,
+            currencyCode: 'EUR',
+            localeCode: 'de_DE',
+        );
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame([
+            'order_number' => '000000042',
+            'order_total' => '4250',
+            'currency' => 'EUR',
+            'locale' => 'de_DE',
+        ], $params);
+    }
+
+    public function test_it_omits_order_number_when_null(): void
+    {
+        $paymentRequest = $this->wrapOrder(
+            number: null,
+            total: 1500,
+            currencyCode: 'USD',
+            localeCode: 'en_US',
+        );
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertArrayNotHasKey('order_number', $params);
+        self::assertSame('1500', $params['order_total']);
+        self::assertSame('USD', $params['currency']);
+        self::assertSame('en_US', $params['locale']);
+    }
+
+    public function test_it_omits_currency_when_null(): void
+    {
+        $paymentRequest = $this->wrapOrder(
+            number: 'X',
+            total: 100,
+            currencyCode: null,
+            localeCode: 'en_US',
+        );
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertArrayNotHasKey('currency', $params);
+    }
+
+    public function test_it_omits_locale_when_null(): void
+    {
+        $paymentRequest = $this->wrapOrder(
+            number: 'X',
+            total: 100,
+            currencyCode: 'USD',
+            localeCode: null,
+        );
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertArrayNotHasKey('locale', $params);
+    }
+
+    public function test_it_returns_early_when_order_is_null(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn(null);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $params = ['untouched' => true];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(['untouched' => true], $params);
+    }
+
+    private function wrapOrder(
+        ?string $number,
+        int $total,
+        ?string $currencyCode,
+        ?string $localeCode,
+    ): PaymentRequestInterface {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getNumber')->willReturn($number);
+        $order->method('getTotal')->willReturn($total);
+        $order->method('getCurrencyCode')->willReturn($currencyCode);
+        $order->method('getLocaleCode')->willReturn($localeCode);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        return $paymentRequest;
+    }
+}

--- a/tests/Unit/Provider/ProductCategoriesMetadataProviderTest.php
+++ b/tests/Unit/Provider/ProductCategoriesMetadataProviderTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Provider;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use FluxSE\SyliusStripePlugin\Provider\ProductCategoriesMetadataProvider;
+use PHPUnit\Framework\TestCase;
+use Stripe\PaymentIntent;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class ProductCategoriesMetadataProviderTest extends TestCase
+{
+    /** @var ProductCategoriesMetadataProvider<PaymentIntent> */
+    private ProductCategoriesMetadataProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new ProductCategoriesMetadataProvider();
+    }
+
+    public function test_it_joins_distinct_lowercased_codes(): void
+    {
+        $paymentRequest = $this->wrapOrderWithTaxonCodes(['MUGS', 'TEA']);
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(['product_categories' => 'mugs,tea'], $params);
+    }
+
+    public function test_it_lowercases_mixed_case_codes(): void
+    {
+        $paymentRequest = $this->wrapOrderWithTaxonCodes(['Kitchen', 'GROCERIES']);
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(['product_categories' => 'kitchen,groceries'], $params);
+    }
+
+    public function test_it_deduplicates_repeated_taxon_codes(): void
+    {
+        $paymentRequest = $this->wrapOrderWithTaxonCodes(['MUGS', 'MUGS', 'MUGS', 'TEA']);
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(['product_categories' => 'mugs,tea'], $params);
+    }
+
+    public function test_it_deduplicates_codes_that_differ_only_by_case(): void
+    {
+        $paymentRequest = $this->wrapOrderWithTaxonCodes(['MUGS', 'mugs', 'Mugs']);
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(['product_categories' => 'mugs'], $params);
+    }
+
+    public function test_it_caps_categories_at_ten(): void
+    {
+        $codes = [];
+        for ($i = 0; $i < 15; ++$i) {
+            $codes[] = 'CAT_' . $i;
+        }
+
+        $paymentRequest = $this->wrapOrderWithTaxonCodes($codes);
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(
+            ['product_categories' => 'cat_0,cat_1,cat_2,cat_3,cat_4,cat_5,cat_6,cat_7,cat_8,cat_9'],
+            $params,
+        );
+    }
+
+    public function test_it_omits_key_when_no_taxons(): void
+    {
+        $paymentRequest = $this->wrapOrderWithTaxonCodes([]);
+
+        $params = [];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame([], $params);
+    }
+
+    public function test_it_skips_items_without_product_or_taxon_or_code(): void
+    {
+        $itemWithoutProduct = $this->createMock(OrderItemInterface::class);
+        $itemWithoutProduct->method('getProduct')->willReturn(null);
+
+        $itemWithoutTaxon = $this->createMock(OrderItemInterface::class);
+        $productWithoutTaxon = $this->createMock(ProductInterface::class);
+        $productWithoutTaxon->method('getMainTaxon')->willReturn(null);
+        $itemWithoutTaxon->method('getProduct')->willReturn($productWithoutTaxon);
+
+        $itemWithValidTaxon = $this->createOrderItem('TEA');
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getItems')->willReturn(new ArrayCollection([
+            $itemWithoutProduct,
+            $itemWithoutTaxon,
+            $itemWithValidTaxon,
+        ]));
+
+        $params = [];
+        $this->provider->provide($this->wrapOrder($order), $params);
+
+        self::assertSame(['product_categories' => 'tea'], $params);
+    }
+
+    public function test_it_returns_early_when_order_is_null(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn(null);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $params = ['untouched' => true];
+        $this->provider->provide($paymentRequest, $params);
+
+        self::assertSame(['untouched' => true], $params);
+    }
+
+    /**
+     * @param list<string> $taxonCodes
+     */
+    private function wrapOrderWithTaxonCodes(array $taxonCodes): PaymentRequestInterface
+    {
+        $items = [];
+        foreach ($taxonCodes as $code) {
+            $items[] = $this->createOrderItem($code);
+        }
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getItems')->willReturn(new ArrayCollection($items));
+
+        return $this->wrapOrder($order);
+    }
+
+    private function createOrderItem(string $taxonCode): OrderItemInterface
+    {
+        $taxon = $this->createMock(TaxonInterface::class);
+        $taxon->method('getCode')->willReturn($taxonCode);
+
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getMainTaxon')->willReturn($taxon);
+
+        $item = $this->createMock(OrderItemInterface::class);
+        $item->method('getProduct')->willReturn($product);
+
+        return $item;
+    }
+
+    private function wrapOrder(OrderInterface $order): PaymentRequestInterface
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        return $paymentRequest;
+    }
+}

--- a/tests/Unit/Provider/Transition/Checkout/PaymentModeTransitionProviderTest.php
+++ b/tests/Unit/Provider/Transition/Checkout/PaymentModeTransitionProviderTest.php
@@ -131,7 +131,7 @@ final class PaymentModeTransitionProviderTest extends TestCase
             $paymentIntentStatus,
             $sessionPaymentStatus,
             null,
-            $chargeRefunded
+            $chargeRefunded,
         );
 
         $result = $this->provider->isRefund($session);
@@ -218,7 +218,7 @@ final class PaymentModeTransitionProviderTest extends TestCase
         string $paymentIntentStatus,
         string $sessionPaymentStatus = Session::PAYMENT_STATUS_PAID,
         ?array $lastPaymentError = null,
-        bool $chargeRefunded = false
+        bool $chargeRefunded = false,
     ): Session {
         $paymentIntentData = [
             'id' => 'pi_test_1',
@@ -248,4 +248,3 @@ final class PaymentModeTransitionProviderTest extends TestCase
         ]);
     }
 }
-

--- a/tests/Unit/Provider/Transition/Checkout/SubscriptionModeTransitionProviderTest.php
+++ b/tests/Unit/Provider/Transition/Checkout/SubscriptionModeTransitionProviderTest.php
@@ -133,7 +133,7 @@ final class SubscriptionModeTransitionProviderTest extends TestCase
             $paymentIntentStatus,
             $sessionPaymentStatus,
             null,
-            $chargeRefunded
+            $chargeRefunded,
         );
 
         $result = $this->provider->isRefund($session);
@@ -263,7 +263,7 @@ final class SubscriptionModeTransitionProviderTest extends TestCase
         string $sessionPaymentStatus = Session::PAYMENT_STATUS_PAID,
         ?array $lastPaymentError = null,
         bool $chargeRefunded = false,
-        bool $includeCharge = true
+        bool $includeCharge = true,
     ): Session {
         $paymentIntentData = [
             'id' => 'pi_test_1',
@@ -309,4 +309,3 @@ final class SubscriptionModeTransitionProviderTest extends TestCase
         ]);
     }
 }
-


### PR DESCRIPTION
### Summary

Adds order-level metadata to the PaymentIntent created by both gateways (Stripe Checkout via `payment_intent_data.metadata`, Stripe Web Elements directly), so merchants can write Radar fraud rules against order context and see richer payment info in the Stripe Dashboard without touching plugin code.

### New metadata keys

- `order_number`, 
- `order_total` (minor units), 
- `currency`, 
- `locale`
- `product_categories` — lowercased Sylius taxon codes,
- `first_order` — `yes`/`no`, omitted for guests

Each is a small `InnerParamsProviderInterface` service tagged into the existing metadata pipeline. The existing `CompositeMetadataParamsProvider` is reused under a new tag for the Checkout `payment_intent_data.metadata` branch (Stripe doesn't propagate `session.metadata` onto the underlying PaymentIntent — Radar only reads PaymentIntent metadata).