### PR TITLE
[Admin][Docs] Link to Stripe restricted API keys documentation in admin warning, README and UPGRADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ https://dashboard.stripe.com/test/apikeys
 
 In that case, paste a standard secret key (`sk_test_…` / `sk_live_…`) into the "Restricted API key (recommended) or secret key" field.
 
+Restricted API keys are Stripe's officially recommended replacement for standard secret keys, see [Stripe's documentation on restricted API keys][link-stripe-restricted-keys] for the full rationale.
+
 ### Webhook key
 
 Got to :
@@ -194,3 +196,4 @@ This plugin is released under the [MIT License](LICENSE).
 [link-total-downloads]: https://packagist.org/packages/flux-se/sylius-stripe-plugin
 [link-github-actions]: https://github.com/FLUX-SE/SyliusStripePlugin/actions?query=workflow%3A"Build"
 [link-sylius-stripe-app]: https://marketplace.stripe.com/apps/install/link/com.sylius.stripe
+[link-stripe-restricted-keys]: https://docs.stripe.com/keys/restricted-api-keys

--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -20,4 +20,7 @@ both keys you need:
 The App ships with the minimum scopes the plugin needs, and **standard secret keys (`sk_*`) will no longer be supported 
 in plugin 2.0** — only Restricted API Keys (`rk_*`) will be accepted. Migrating now keeps you ahead of that change.
 
+For Stripe's own rationale on why restricted keys exist and how they differ from standard secret keys, see [Stripe's documentation on restricted API keys][link-stripe-restricted-keys].
+
 [link-sylius-stripe-app]: https://marketplace.stripe.com/apps/install/link/com.sylius.stripe
+[link-stripe-restricted-keys]: https://docs.stripe.com/keys/restricted-api-keys

--- a/templates/admin/payment_method/form/publishable_key.html.twig
+++ b/templates/admin/payment_method/form/publishable_key.html.twig
@@ -11,8 +11,13 @@
             <div class="d-flex align-items-start">
                 <div class="me-2">{{ ux_icon('tabler:alert-triangle', {'class': 'icon alert-icon text-warning'}) }}</div>
                 <div>
-                    <p class="fw-bold mb-0">
+                    <p class="fw-bold">
                         {{ 'flux_se_sylius_stripe_plugin.form.gateway_configuration.stripe.info.secret_key_legacy_warning'|trans }}
+                    </p>
+                    <p class="mb-0">
+                        <a class="fw-bold text-decoration-none" href="https://docs.stripe.com/keys/restricted-api-keys" target="_blank" rel="noopener noreferrer">
+                            {{ 'flux_se_sylius_stripe_plugin.form.gateway_configuration.stripe.action.learn_more_restricted_keys'|trans }}
+                        </a>
                     </p>
                 </div>
             </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -20,8 +20,9 @@ flux_se_sylius_stripe_plugin:
                     payment_method_type: It's normally not necessary to define payment methods here, you can manage them using the Stripe dashboard.
                 action:
                     open_stripe_app: Open Sylius Stripe App
-                    secret_key: Open Stripe Dashboard API keys.
-                    webhook_secret_key: Create a new webhook endpoint.
+                    learn_more_restricted_keys: Learn more about restricted API keys
+                    secret_key: Open Stripe Dashboard API keys
+                    webhook_secret_key: Create a new webhook endpoint
     order_pay:
         web_elements:
             pay: Pay

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -20,8 +20,9 @@ flux_se_sylius_stripe_plugin:
                     payment_method_type: Il n'est normalement pas nécessaire de définir des méthodes de paiement, vous pouvez les gérer dans votre tableau de bord Stripe.
                 action:
                     open_stripe_app: Ouvrir l'application Sylius Stripe
-                    secret_key: Ouvrir les clés API du tableau de bord Stripe.
-                    webhook_secret_key: Créez un nouveau webhook endpoint.
+                    learn_more_restricted_keys: En savoir plus sur les clés d'API restreintes
+                    secret_key: Ouvrir les clés API du tableau de bord Stripe
+                    webhook_secret_key: Créez un nouveau webhook endpoint
     order_pay:
         web_elements:
             pay: Payer


### PR DESCRIPTION
<img width="1340" height="383" alt="image" src="https://github.com/user-attachments/assets/1fa0805d-a728-4cf2-8321-a0f81b90164f" />
