### PR TITLE
[Shop] Pass customer email to Web Elements Payment Element for Stripe Link

### DIFF
--- a/src/OrderPay/Provider/WebElements/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/WebElements/CaptureHttpResponseProvider.php
@@ -8,6 +8,7 @@ use FluxSE\SyliusStripePlugin\Provider\AfterUrlProviderInterface;
 use Stripe\PaymentIntent;
 use Sylius\Bundle\PaymentBundle\Provider\HttpResponseProviderInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
@@ -39,13 +40,18 @@ final readonly class CaptureHttpResponseProvider implements HttpResponseProvider
             throw new \LogicException('The publishable key must be defined!');
         }
 
+        /** @var PaymentInterface $payment */
+        $payment = $paymentRequest->getPayment();
+        $customerEmail = $payment->getOrder()?->getCustomer()?->getEmail();
+
         return new Response(
             $this->twig->render(
                 '@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture.html.twig',
                 [
                     'publishable_key' => $publishableKey,
-                    'model' => PaymentIntent::constructFrom($paymentRequest->getPayment()->getDetails()),
+                    'model' => PaymentIntent::constructFrom($payment->getDetails()),
                     'action_url' => $this->afterUrlProvider->getUrl($paymentRequest, AfterUrlProviderInterface::ACTION_URL),
+                    'customer_email' => $customerEmail,
                 ],
             ),
         );

--- a/templates/shop/order_pay/web_elements/capture/javascript_common.html.twig
+++ b/templates/shop/order_pay/web_elements/capture/javascript_common.html.twig
@@ -2,6 +2,7 @@
 {# @var model \Stripe\PaymentIntent #}
 {% set model = hookable_metadata.context.model %}
 {% set action_url = hookable_metadata.context.action_url %}
+{% set customer_email = hookable_metadata.context.customer_email|default(null) %}
 <script type="text/javascript" defer>
     var stripe = Stripe('{{ publishable_key }}');
     var options = {
@@ -53,7 +54,15 @@
     };
 
     // Create an instance of the payment Element.
-    var paymentElement = elements.create('payment');
+    var paymentElement = elements.create('payment', {
+        {% if customer_email is not empty %}
+        defaultValues: {
+            billingDetails: {
+                email: '{{ customer_email|e('js') }}',
+            },
+        },
+        {% endif %}
+    });
 
     // Add an instance of the card Element into the `card-element` <div>.
     paymentElement.mount('#payment-element');

--- a/tests/Unit/OrderPay/Provider/WebElements/CaptureHttpResponseProviderTest.php
+++ b/tests/Unit/OrderPay/Provider/WebElements/CaptureHttpResponseProviderTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\OrderPay\Provider\WebElements;
+
+use FluxSE\SyliusStripePlugin\OrderPay\Provider\WebElements\CaptureHttpResponseProvider;
+use FluxSE\SyliusStripePlugin\Provider\AfterUrlProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Stripe\PaymentIntent;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+
+final class CaptureHttpResponseProviderTest extends TestCase
+{
+    public function test_it_passes_customer_email_to_template_when_order_has_customer_with_email(): void
+    {
+        $context = $this->captureRenderContext(customerEmail: 'oliver@doe.com');
+
+        self::assertSame('oliver@doe.com', $context['customer_email']);
+    }
+
+    public function test_it_passes_null_email_when_customer_has_no_email(): void
+    {
+        $context = $this->captureRenderContext(customerEmail: null);
+
+        self::assertNull($context['customer_email']);
+    }
+
+    public function test_it_passes_null_email_when_order_has_no_customer(): void
+    {
+        $context = $this->captureRenderContext(customerEmail: null, omitCustomer: true);
+
+        self::assertNull($context['customer_email']);
+    }
+
+    public function test_it_passes_publishable_key_and_action_url_and_model_to_template(): void
+    {
+        $context = $this->captureRenderContext(customerEmail: 'oliver@doe.com');
+
+        self::assertSame('pk_test_xyz', $context['publishable_key']);
+        self::assertSame('https://example.com/after', $context['action_url']);
+        self::assertInstanceOf(PaymentIntent::class, $context['model']);
+        self::assertSame('pi_test_secret', $context['model']->client_secret);
+    }
+
+    /** @return array<string, mixed> */
+    private function captureRenderContext(?string $customerEmail, bool $omitCustomer = false): array
+    {
+        if ($omitCustomer) {
+            $customer = null;
+        } else {
+            $customer = $this->createMock(CustomerInterface::class);
+            $customer->method('getEmail')->willReturn($customerEmail);
+        }
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCustomer')->willReturn($customer);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getDetails')->willReturn(['client_secret' => 'pi_test_secret']);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $paymentRequest->method('getResponseData')->willReturn(['publishable_key' => 'pk_test_xyz']);
+
+        $afterUrlProvider = $this->createMock(AfterUrlProviderInterface::class);
+        $afterUrlProvider->method('getUrl')
+            ->with($paymentRequest, AfterUrlProviderInterface::ACTION_URL)
+            ->willReturn('https://example.com/after');
+
+        $capturedContext = null;
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::once())
+            ->method('render')
+            ->with('@FluxSESyliusStripePlugin/shop/order_pay/web_elements/capture.html.twig')
+            ->willReturnCallback(function (string $template, array $context) use (&$capturedContext): string {
+                $capturedContext = $context;
+
+                return '';
+            });
+
+        $provider = new CaptureHttpResponseProvider($afterUrlProvider, $twig);
+
+        $response = $provider->getResponse($this->createMock(RequestConfiguration::class), $paymentRequest);
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertIsArray($capturedContext);
+
+        return $capturedContext;
+    }
+}


### PR DESCRIPTION
### Summary

Pass the customer's email to the Stripe Web Elements Payment Element via `defaultValues.billingDetails.email` so that Stripe Link recognises returning customers immediately on page load instead of relying solely on browser cookies.

As a logged in customer with an account in Link:
<img width="1432" height="874" alt="image" src="https://github.com/user-attachments/assets/610b32a1-684b-471b-81c7-a0c356b5dc10" />

Refs: 
- https://docs.stripe.com/payments/link
- https://docs.stripe.com/payments/link/payment-element-link