### PR TITLE
[Shop][ExpressCheckout] Sync wallet total with Sylius cart on address and rate changes

### DIFF
--- a/assets/shop/js/express-checkout/core.js
+++ b/assets/shop/js/express-checkout/core.js
@@ -154,6 +154,16 @@ export async function initExpressCheckout(container) {
         });
     });
 
+    // Stripe ECE validates `elements.amount === sum(lineItems) + selectedShippingRate.amount`
+    // on every resolve(). The backend ships a precomputed `totalAmount` so the frontend
+    // doesn't have to know how lineItems are composed — push it to elements *before*
+    // resolve(), otherwise the wallet popup throws IntegrationError and hangs.
+    //
+    // The `shippingratechange` event in the Stripe ECE spec carries only `event.shippingRate`,
+    // not the address — keep the last address from `shippingaddresschange` so the rate-change
+    // POST still satisfies the backend's address requirement.
+    let lastShippingAddress = null;
+
     expressCheckout.on('shippingaddresschange', async (event) => {
         const result = await postJson(shippingRatesUrl, { address: event.address }, csrfToken);
         if (!result || result.error || !Array.isArray(result.shippingRates) || result.shippingRates.length === 0) {
@@ -161,6 +171,8 @@ export async function initExpressCheckout(container) {
 
             return;
         }
+        lastShippingAddress = event.address;
+        await elements.update({ amount: result.totalAmount });
         event.resolve({
             shippingRates: result.shippingRates,
             lineItems: result.lineItems,
@@ -168,11 +180,22 @@ export async function initExpressCheckout(container) {
     });
 
     expressCheckout.on('shippingratechange', async (event) => {
+        if (!lastShippingAddress) {
+            event.reject();
+
+            return;
+        }
         const result = await postJson(shippingRatesUrl, {
-            address: event.address,
+            address: lastShippingAddress,
             shippingRateId: event.shippingRate.id,
         }, csrfToken);
-        event.resolve({ lineItems: (result && result.lineItems) || [] });
+        if (!result || result.error) {
+            event.reject();
+
+            return;
+        }
+        await elements.update({ amount: result.totalAmount });
+        event.resolve({ lineItems: result.lineItems || [] });
     });
 
     // The wallet popup can fire `confirm` more than once: double-click on the wallet

--- a/src/ExpressCheckout/Dto/ExpressCheckoutShippingOptions.php
+++ b/src/ExpressCheckout/Dto/ExpressCheckoutShippingOptions.php
@@ -13,6 +13,7 @@ final readonly class ExpressCheckoutShippingOptions
     public function __construct(
         public array $shippingRates,
         public array $lineItems,
+        public int $totalAmount,
     ) {
     }
 
@@ -20,6 +21,7 @@ final readonly class ExpressCheckoutShippingOptions
      * @return array{
      *     shippingRates: list<array{id: string, displayName: string, amount: int, currency: string|null}>,
      *     lineItems: list<array{name: string, amount: int}>,
+     *     totalAmount: int,
      * }
      */
     public function toArray(): array
@@ -27,6 +29,7 @@ final readonly class ExpressCheckoutShippingOptions
         return [
             'shippingRates' => array_map(static fn (ExpressCheckoutShippingRate $rate): array => $rate->toArray(), $this->shippingRates),
             'lineItems' => array_map(static fn (ExpressCheckoutLineItem $item): array => $item->toArray(), $this->lineItems),
+            'totalAmount' => $this->totalAmount,
         ];
     }
 }

--- a/src/ExpressCheckout/ShippingOptionsCalculator.php
+++ b/src/ExpressCheckout/ShippingOptionsCalculator.php
@@ -58,6 +58,7 @@ final readonly class ShippingOptionsCalculator implements ShippingOptionsCalcula
             return new ExpressCheckoutShippingOptions(
                 shippingRates: [],
                 lineItems: $this->buildLineItems($cart),
+                totalAmount: $cart->getTotal(),
             );
         }
 
@@ -69,18 +70,19 @@ final readonly class ShippingOptionsCalculator implements ShippingOptionsCalcula
         $shippingRateId = $payload->getShippingRateId();
         $chosenMethod = null !== $shippingRateId ? $this->resolveChosenMethod($shippingRateId, $supportedMethods) : null;
 
-        $shipment->setMethod($chosenMethod ?? $originalMethod ?? $supportedMethods[0] ?? null);
+        // Align the shipment with the rate the wallet will display: the customer-picked
+        // rate when provided, otherwise rates[0] which is what Stripe ECE defaults to.
+        $previewMethod = $chosenMethod ?? $supportedMethods[0] ?? $originalMethod;
+        $shipment->setMethod($previewMethod);
 
-        // Re-process only when the customer actually picked a shipping rate — the address-
-        // preview path (shippingaddresschange without shippingRateId) doesn't need a second
-        // OrderProcessor pass and the extra round-trip pushed us over Stripe's ECE timeout.
-        if (null !== $chosenMethod) {
+        if ($previewMethod !== $originalMethod) {
             $this->orderProcessor->process($cart);
         }
 
         return new ExpressCheckoutShippingOptions(
             shippingRates: $rates,
             lineItems: $this->buildLineItems($cart),
+            totalAmount: $cart->getTotal(),
         );
     }
 
@@ -121,17 +123,30 @@ final readonly class ShippingOptionsCalculator implements ShippingOptionsCalcula
     /**
      * Line items rendered by Stripe's Express Checkout Element next to the wallet
      * "Pay" button. Shipping must NOT be included — Stripe adds the cost of the
-     * customer-selected `shippingRate` on top of `sum(lineItems)`, so including it
-     * here would count shipping twice and trip the guard
-     * "amount is less than the total amount of the line items provided".
+     * customer-selected `shippingRate` on top of `sum(lineItems)`.
+     *
+     * Mode-agnostic decomposition using Sylius's canonical helpers:
+     *
+     *  - `Subtotal` = `Order::getItemsSubtotal()` (sum of `unit_price + unit_promotion`).
+     *    In tax-excluded channels this is items net; in tax-included channels it is
+     *    items gross — matching what the customer sees in the catalog.
+     *  - `Tax` = `Order::getTaxExcludedTotal()` (sum of NON-neutral tax adjustments,
+     *    i.e. the tax that Sylius adds on top of unit prices). In excluded channels
+     *    this is the visible tax line; in included channels it is 0 (tax adjustments
+     *    are neutral, already baked into the unit prices) and we drop the Tax line.
      *
      * @return list<ExpressCheckoutLineItem>
      */
     private function buildLineItems(OrderInterface $cart): array
     {
-        return [
-            new ExpressCheckoutLineItem(name: 'Subtotal', amount: $cart->getItemsTotal()),
-            new ExpressCheckoutLineItem(name: 'Tax', amount: $cart->getTaxTotal()),
-        ];
+        $subtotal = $cart->getItemsSubtotal();
+        $tax = $cart->getTaxExcludedTotal();
+
+        $lineItems = [new ExpressCheckoutLineItem(name: 'Subtotal', amount: $subtotal)];
+        if ($tax > 0) {
+            $lineItems[] = new ExpressCheckoutLineItem(name: 'Tax', amount: $tax);
+        }
+
+        return $lineItems;
     }
 }

--- a/tests/Unit/ExpressCheckout/ShippingOptionsCalculatorTest.php
+++ b/tests/Unit/ExpressCheckout/ShippingOptionsCalculatorTest.php
@@ -115,8 +115,9 @@ final class ShippingOptionsCalculatorTest extends TestCase
         $cart->expects(self::once())->method('setBillingAddress');
 
         $cart->method('getShipments')->willReturn(new ArrayCollection([]));
-        $cart->method('getItemsTotal')->willReturn(2000);
-        $cart->method('getTaxTotal')->willReturn(100);
+        $cart->method('getTotal')->willReturn(2100);
+        $cart->method('getItemsSubtotal')->willReturn(2000);
+        $cart->method('getTaxExcludedTotal')->willReturn(100);
 
         $this->cartContext->method('getCart')->willReturn($cart);
         $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload(['address' => ['country' => 'US']]));
@@ -133,38 +134,161 @@ final class ShippingOptionsCalculatorTest extends TestCase
         self::assertSame(2000, $options->lineItems[0]->amount);
         self::assertSame('Tax', $options->lineItems[1]->name);
         self::assertSame(100, $options->lineItems[1]->amount);
+        // No shipment → totalAmount = cart.getTotal(); frontend rejects the change anyway.
+        self::assertSame(2100, $options->totalAmount);
     }
 
-    public function test_it_does_not_reprocess_the_order_when_no_shipping_rate_is_chosen(): void
+    public function test_it_skips_reprocess_when_cart_is_already_aligned_with_first_rate(): void
     {
+        // Cart was already processed with supportedMethods[0] = UPS (which is what
+        // Stripe ECE will preview as the default rate). No need to re-process — cart.getTotal()
+        // already reflects the previewed shipping method.
+        // Real user numbers (Summer Bloom Jeans, US/NY, UPS, tax-excluded channel):
+        // items net $18.58 + tax $1.30 + shipping $9.91 → cart total $29.79.
         $shipment = $this->createMock(ShipmentInterface::class);
         $supportedMethod = $this->createShippingMethod('ups');
         $cart = $this->createReadyCart();
         $cart->method('getCurrencyCode')->willReturn('USD');
         $cart->method('getBillingAddress')->willReturn($this->createMock(AddressInterface::class));
         $cart->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
-        $cart->method('getItemsTotal')->willReturn(5000);
-        $cart->method('getTaxTotal')->willReturn(200);
+        $cart->method('getTotal')->willReturn(2979);
+        $cart->method('getItemsSubtotal')->willReturn(1858);
+        $cart->method('getTaxExcludedTotal')->willReturn(130);
 
         $this->cartContext->method('getCart')->willReturn($cart);
         $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload(['address' => ['country' => 'US']]));
         $this->addressNormalizer->method('normalizeAddress')->willReturn($this->createMock(AddressInterface::class));
 
         $this->shippingMethodsResolver->method('getSupportedMethods')->with($shipment)->willReturn([$supportedMethod]);
-        $shipment->method('getMethod')->willReturn(null);
+        // originalMethod == supportedMethods[0] → previewMethod equals originalMethod → skip second pass.
+        $shipment->method('getMethod')->willReturn($supportedMethod);
 
-        $rate = new ExpressCheckoutShippingRate('ups', 'UPS', 599, 'usd');
+        $rate = new ExpressCheckoutShippingRate('ups', 'UPS', 991, 'usd');
         $this->shippingRateAssembler->method('assemble')->willReturn([$rate]);
 
-        // Address-preview path: only ONE OrderProcessor pass — the second one is the optimization we're guarding.
         $this->orderProcessor->expects(self::once())->method('process')->with($cart);
 
-        // The fallback supported method is set on the shipment after rates are assembled.
         $shipment->expects(self::once())->method('setMethod')->with($supportedMethod);
 
         $options = $this->calculator->calculate(new Request());
 
         self::assertSame([$rate], $options->shippingRates);
+        self::assertSame(1858, $options->lineItems[0]->amount);
+        self::assertSame(130, $options->lineItems[1]->amount);
+        self::assertSame(2979, $options->totalAmount);
+    }
+
+    public function test_it_reprocesses_cart_when_previewed_method_differs_from_original(): void
+    {
+        // shippingaddresschange path with no shippingRateId: shipment has no method set yet,
+        // so previewMethod = supportedMethods[0] (FedEx) differs from originalMethod (null).
+        // The calculator runs a second OrderProcessor pass so cart.getTotal() reflects FedEx
+        // (rather than the pre-process state) — keeping cart.getTotal() the authoritative
+        // value the backend will charge.
+        $shipment = $this->createMock(ShipmentInterface::class);
+        $fedex = $this->createShippingMethod('fedex');
+        $cart = $this->createReadyCart();
+        $cart->method('getCurrencyCode')->willReturn('USD');
+        $cart->method('getBillingAddress')->willReturn($this->createMock(AddressInterface::class));
+        $cart->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
+        // After the second process pass with FedEx selected.
+        $cart->method('getTotal')->willReturn(2845);
+        $cart->method('getItemsSubtotal')->willReturn(1858);
+        $cart->method('getTaxExcludedTotal')->willReturn(130);
+
+        $this->cartContext->method('getCart')->willReturn($cart);
+        $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload(['address' => ['country' => 'US']]));
+        $this->addressNormalizer->method('normalizeAddress')->willReturn($this->createMock(AddressInterface::class));
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$fedex]);
+        $shipment->method('getMethod')->willReturn(null);
+
+        $fedexRate = new ExpressCheckoutShippingRate('fedex', 'FedEx', 857, 'usd');
+        $this->shippingRateAssembler->method('assemble')->willReturn([$fedexRate]);
+
+        $this->orderProcessor->expects(self::exactly(2))->method('process')->with($cart);
+        $shipment->expects(self::once())->method('setMethod')->with($fedex);
+
+        $options = $this->calculator->calculate(new Request());
+
+        self::assertSame(2845, $options->totalAmount);
+        self::assertSame(1858, $options->lineItems[0]->amount);
+        self::assertSame(130, $options->lineItems[1]->amount);
+    }
+
+    public function test_it_skips_tax_line_when_subtotal_already_includes_tax(): void
+    {
+        // Tax-included channel: tax_rate.includedInPrice=true → unit_price is gross,
+        // tax adjustment is NEUTRAL (skipped from cart.getTotal()). The customer sees
+        // $19.88 gross in the catalog; the wallet popup should mirror that, not break
+        // it into a confusing $18.58 + $1.30.
+        $shipment = $this->createMock(ShipmentInterface::class);
+        $ups = $this->createShippingMethod('ups');
+        $cart = $this->createReadyCart();
+        $cart->method('getCurrencyCode')->willReturn('USD');
+        $cart->method('getBillingAddress')->willReturn($this->createMock(AddressInterface::class));
+        $cart->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
+        // Same product ($19.88 gross) + same UPS shipping, but tax baked into unit price.
+        // In tax-included mode, all tax adjustments are NEUTRAL → getTaxExcludedTotal() == 0.
+        $cart->method('getTotal')->willReturn(2979);
+        $cart->method('getItemsSubtotal')->willReturn(1988);
+        $cart->method('getTaxExcludedTotal')->willReturn(0);
+
+        $this->cartContext->method('getCart')->willReturn($cart);
+        $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload(['address' => ['country' => 'US']]));
+        $this->addressNormalizer->method('normalizeAddress')->willReturn($this->createMock(AddressInterface::class));
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$ups]);
+        $shipment->method('getMethod')->willReturn(null);
+
+        $rate = new ExpressCheckoutShippingRate('ups', 'UPS', 991, 'usd');
+        $this->shippingRateAssembler->method('assemble')->willReturn([$rate]);
+
+        // Two passes: initial + after aligning shipment with rates[0].
+        $this->orderProcessor->expects(self::exactly(2))->method('process')->with($cart);
+
+        $options = $this->calculator->calculate(new Request());
+
+        // Only Subtotal line — Tax would be 0 because tax is already in the gross unit price.
+        self::assertCount(1, $options->lineItems);
+        self::assertSame('Subtotal', $options->lineItems[0]->name);
+        self::assertSame(1988, $options->lineItems[0]->amount);
+        self::assertSame(2979, $options->totalAmount);
+    }
+
+    public function test_it_keeps_shipping_tax_in_total_when_shipping_is_taxable(): void
+    {
+        // Taxable shipping: the shipping method belongs to a tax category, so the
+        // second OrderProcessor pass produces an additional shipping tax adjustment
+        // that ends up in cart.getTotal() and (recursively) in getTaxExcludedTotal().
+        // totalAmount = cart.getTotal() captures the full amount, including shipping tax,
+        // exactly as Sylius will charge it via the PaymentIntent.
+        $shipment = $this->createMock(ShipmentInterface::class);
+        $ups = $this->createShippingMethod('ups');
+        $cart = $this->createReadyCart();
+        $cart->method('getCurrencyCode')->willReturn('USD');
+        $cart->method('getBillingAddress')->willReturn($this->createMock(AddressInterface::class));
+        $cart->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
+        $cart->method('getTotal')->willReturn(3029);
+        $cart->method('getItemsSubtotal')->willReturn(1858);
+        // items_tax 130 + shipping_tax 50 — both non-neutral, both included recursively.
+        $cart->method('getTaxExcludedTotal')->willReturn(180);
+
+        $this->cartContext->method('getCart')->willReturn($cart);
+        $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload(['address' => ['country' => 'US']]));
+        $this->addressNormalizer->method('normalizeAddress')->willReturn($this->createMock(AddressInterface::class));
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$ups]);
+        $shipment->method('getMethod')->willReturn(null);
+
+        $rate = new ExpressCheckoutShippingRate('ups', 'UPS', 991, 'usd');
+        $this->shippingRateAssembler->method('assemble')->willReturn([$rate]);
+
+        $this->orderProcessor->expects(self::exactly(2))->method('process')->with($cart);
+
+        $options = $this->calculator->calculate(new Request());
+
+        self::assertSame(1858, $options->lineItems[0]->amount);
+        self::assertSame(180, $options->lineItems[1]->amount);
+        // cart.getTotal() — single source of truth, including shipping tax.
+        self::assertSame(3029, $options->totalAmount);
     }
 
     public function test_it_reprocesses_the_order_when_a_shipping_rate_is_chosen(): void
@@ -177,8 +301,10 @@ final class ShippingOptionsCalculatorTest extends TestCase
         $cart->method('getCurrencyCode')->willReturn('USD');
         $cart->method('getBillingAddress')->willReturn($this->createMock(AddressInterface::class));
         $cart->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
-        $cart->method('getItemsTotal')->willReturn(5000);
-        $cart->method('getTaxTotal')->willReturn(200);
+        // After re-processing with chosen rate: cart total reflects items + tax + chosen shipping.
+        $cart->method('getTotal')->willReturn(2916);
+        $cart->method('getItemsSubtotal')->willReturn(1858);
+        $cart->method('getTaxExcludedTotal')->willReturn(130);
 
         $this->cartContext->method('getCart')->willReturn($cart);
         $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload([
@@ -188,14 +314,20 @@ final class ShippingOptionsCalculatorTest extends TestCase
         $this->addressNormalizer->method('normalizeAddress')->willReturn($this->createMock(AddressInterface::class));
         $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$other, $chosen]);
         $shipment->method('getMethod')->willReturn(null);
-        $this->shippingRateAssembler->method('assemble')->willReturn([]);
+
+        $otherRate = new ExpressCheckoutShippingRate('other', 'Other', 991, 'usd');
+        $chosenRate = new ExpressCheckoutShippingRate('chosen', 'Chosen', 928, 'usd');
+        $this->shippingRateAssembler->method('assemble')->willReturn([$otherRate, $chosenRate]);
 
         // Confirm path: TWO OrderProcessor passes — initial + after the chosen rate is applied.
         $this->orderProcessor->expects(self::exactly(2))->method('process')->with($cart);
 
         $shipment->expects(self::once())->method('setMethod')->with($chosen);
 
-        $this->calculator->calculate(new Request());
+        $options = $this->calculator->calculate(new Request());
+
+        // shippingratechange path: cart was re-processed with the chosen method, so totalAmount == cart.getTotal().
+        self::assertSame(2916, $options->totalAmount);
     }
 
     public function test_it_falls_back_to_the_repository_when_chosen_method_is_not_in_supported_set(): void
@@ -208,8 +340,9 @@ final class ShippingOptionsCalculatorTest extends TestCase
         $cart->method('getCurrencyCode')->willReturn('USD');
         $cart->method('getBillingAddress')->willReturn($this->createMock(AddressInterface::class));
         $cart->method('getShipments')->willReturn(new ArrayCollection([$shipment]));
-        $cart->method('getItemsTotal')->willReturn(0);
-        $cart->method('getTaxTotal')->willReturn(0);
+        $cart->method('getTotal')->willReturn(0);
+        $cart->method('getItemsSubtotal')->willReturn(0);
+        $cart->method('getTaxExcludedTotal')->willReturn(0);
 
         $this->cartContext->method('getCart')->willReturn($cart);
         $this->payloadReader->method('read')->willReturn(new ExpressCheckoutPayload([


### PR DESCRIPTION
## Summary

  Fixes for the Express Checkout (ECE) wallet flow on the cart and checkout-address-step
  placements. The wallet popup was either hanging with an `IntegrationError`, or — worse —
  silently charging the customer a different amount than the one displayed on the Pay button.
  Root cause was a mix of frontend/backend issues compounding the same Stripe ECE
  contract: `elements.amount === sum(lineItems) + selectedShippingRate.amount`.

  ## What was fixed

  - **Wallet popup no longer hangs after the customer picks an address.** The
    `shippingaddresschange` / `shippingratechange` handlers now call
    `elements.update({ amount })` before resolving the event, so Stripe ECE no longer
    trips the "amount is less than the total amount of the line items provided"
    `IntegrationError`. The new amount comes from a server-computed `totalAmount` in the
    `/express-checkout/shipping-rates` response — frontend stays a thin proxy.

  - **`shippingratechange` no longer 422s.** The Stripe ECE event for this change carries
    only `shippingRate`, not the address. The frontend now keeps the address from the
    preceding `shippingaddresschange` in a closure and sends it on every rate-change POST,
    so the backend's "missing address" guard stops firing.

  - **Wallet total now matches `cart.getTotal()` exactly.** Previously the calculator
    derived `totalAmount` arithmetically (e.g. `getTotal() - getShippingTotal() + rate`),
    which silently dropped shipping tax (because `Order::getShippingTotal()` already
    includes it in Sylius). The calculator now re-processes the cart with the previewed
    shipping method set and returns `cart.getTotal()` directly — the same value the
    backend will later use to create the PaymentIntent, so the wallet display and the
    charged amount cannot diverge.

  - **Line-item decomposition handles both tax modes.** `buildLineItems()` now uses
    Sylius's canonical `Order::getItemsSubtotal()` and `Order::getTaxExcludedTotal()`
    instead of arithmetic on `getItemsTotal/getTaxTotal`:
    - **Tax-excluded channels** show `Subtotal $18.58 + Tax $1.30`.
    - **Tax-included channels** show `Subtotal $19.88` (gross, matches catalog) and the
      Tax line is dropped entirely (would be 0 — tax adjustments are neutral and already
      baked into the unit price).
    - **Taxable shipping** (shipping method belongs to a tax category) is now included
      in the displayed Tax line via the recursive `getTaxExcludedTotal()`.

  ## Cases verified

  | Scenario | Before | After |
  |---|---|---|
  | Link wallet, US address, tax-excluded channel, UPS shipping | hang or wrong total | Total $29.79, breakdown matches |
  | Switch shipping rate in popup (UPS → DHL → FedEx) | 422 "Missing address" | Total updates per rate |
  | Taxable shipping ($9.91 cost + $0.50 shipping tax) | shipping tax dropped from total | full $30.29 charged |
  | Tax-included channel (gross unit prices) | "Subtotal $17.28 + Tax $1.30" (confusing) | "Subtotal $19.88", no Tax line |