### PR TITLE
[Admin] Fix Complete/Cancel on Authorized order by expanding latest_charge on PaymentIntent capture/cancel

### DIFF
--- a/config/services/managers.yaml
+++ b/config/services/managers.yaml
@@ -34,11 +34,13 @@ services:
         class: FluxSE\SyliusStripePlugin\Manager\WebElements\CaptureManager
         arguments:
             - '@flux_se.sylius_stripe.stripe.factory.client'
-    
+            - '@flux_se.sylius_stripe.provider.payment_intent.capture.params'
+
     flux_se.sylius_stripe.manager.checkout.cancel_authorized:
         class: FluxSE\SyliusStripePlugin\Manager\WebElements\CancelManager
         arguments:
             - '@flux_se.sylius_stripe.stripe.factory.client'
+            - '@flux_se.sylius_stripe.provider.payment_intent.cancel.params'
 
     flux_se.sylius_stripe.manager.web_elements.create:
         class: FluxSE\SyliusStripePlugin\Manager\WebElements\CreateManager
@@ -60,6 +62,7 @@ services:
         class: FluxSE\SyliusStripePlugin\Manager\WebElements\CancelManager
         arguments:
             - '@flux_se.sylius_stripe.stripe.factory.client'
+            - '@flux_se.sylius_stripe.provider.payment_intent.cancel.params'
     FluxSE\SyliusStripePlugin\Manager\WebElements\CancelManagerInterface:
         alias: flux_se.sylius_stripe.manager.web_elements.cancel
 
@@ -67,6 +70,7 @@ services:
         class: FluxSE\SyliusStripePlugin\Manager\WebElements\CaptureManager
         arguments:
             - '@flux_se.sylius_stripe.stripe.factory.client'
+            - '@flux_se.sylius_stripe.provider.payment_intent.capture.params'
     FluxSE\SyliusStripePlugin\Manager\WebElements\CaptureManagerInterface:
         alias: flux_se.sylius_stripe.manager.web_elements.capture
 

--- a/config/services/providers/payment_intent/cancel_params_providers.yaml
+++ b/config/services/providers/payment_intent/cancel_params_providers.yaml
@@ -1,0 +1,18 @@
+parameters:
+    flux_se.sylius_stripe.payment_intent.cancel.expand_fields:
+        - 'latest_charge'
+        - 'payment_method'
+
+services:
+    flux_se.sylius_stripe.provider.payment_intent.cancel.params:
+        class: FluxSE\SyliusStripePlugin\Provider\CompositeParamsProvider
+        arguments:
+            - !tagged_iterator flux_se.sylius_stripe.provider.payment_intent.cancel.inner_params
+
+    flux_se.sylius_stripe.provider.payment_intent.cancel.expand:
+        class: FluxSE\SyliusStripePlugin\Provider\ExpandProvider
+        arguments:
+            - '%flux_se.sylius_stripe.payment_intent.cancel.expand_fields%'
+        tags:
+            - name: flux_se.sylius_stripe.provider.payment_intent.cancel.inner_params
+              priority: -100

--- a/config/services/providers/payment_intent/capture_params_providers.yaml
+++ b/config/services/providers/payment_intent/capture_params_providers.yaml
@@ -1,0 +1,18 @@
+parameters:
+    flux_se.sylius_stripe.payment_intent.capture.expand_fields:
+        - 'latest_charge'
+        - 'payment_method'
+
+services:
+    flux_se.sylius_stripe.provider.payment_intent.capture.params:
+        class: FluxSE\SyliusStripePlugin\Provider\CompositeParamsProvider
+        arguments:
+            - !tagged_iterator flux_se.sylius_stripe.provider.payment_intent.capture.inner_params
+
+    flux_se.sylius_stripe.provider.payment_intent.capture.expand:
+        class: FluxSE\SyliusStripePlugin\Provider\ExpandProvider
+        arguments:
+            - '%flux_se.sylius_stripe.payment_intent.capture.expand_fields%'
+        tags:
+            - name: flux_se.sylius_stripe.provider.payment_intent.capture.inner_params
+              priority: -100


### PR DESCRIPTION
### Summary

Admin Complete / Cancel actions on an Authorized order threw a \LogicException from `PaymentIntentTransitionProvider::isChargeRefunded(): the Stripe paymentIntents.capture() / paymentIntents.cancel()` calls succeeded server-side, but the returned PaymentIntent had `latest_charge` as a string ID (not an expanded Charge object), so the local state-machine transition never committed.

### Root cause

The four manager services backing those admin actions (`flux_se.sylius_stripe.manager.{checkout,web_elements}.{capture,cancel,capture_authorized,cancel_authorized}`) were wired with the ClientFactory only — without a params provider — so the Stripe API calls went without any expand directive. The retrieve path already worked correctly because `web_elements.retrieve.expand_fields` covered it.

### Fix

Introduces a neutral `provider.payment_intent.{capture,cancel}.params` composite provider (gateway-agnostic — naming aligned with the existing `provider.refund.create.*` / `provider.invoice.all.*` resource-based convention) that adds `expand=['latest_charge', 'payment_method']` to both capture and cancel calls. The four manager services now receive it as a second constructor argument. Zero PHP changes — both `WebElements\CaptureManager` and `WebElements\CancelManager` already accepted an optional ParamsProviderInterface.

After the fix, the PI returned by Stripe has latest_charge as a Charge object → isChargeRefunded() passes → admin actions commit their local transition without relying on the webhook fallback.