### PR TITLE
[Payment] Skip redundant Stripe action dispatch when state already applied

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -293,4 +293,17 @@ Sylius test attributes referenced inside these templates (`config-publishable-ke
 If you registered hooks at any of the old priorities to slot a custom field between existing ones, recompute against
 the new scheme (step 50).
 
+## `PaymentStateProcessor` constructor signature changed
+
+`FluxSE\SyliusStripePlugin\StateMachine\PaymentStateProcessor` gained a new constructor argument
+`StripeStateAppliedCheckerInterface $stripeStateAppliedChecker`, inserted **before** the existing
+`array $supportedFactories` argument.
+
+The new service is wired automatically through the abstract `flux_se.sylius_stripe.state_machine.payment_state`
+definition (`config/services/state_machine.yaml`).
+
+**You must migrate if** you instantiate `PaymentStateProcessor` directly in PHP or via a manual service
+definition that does **not** `parent:` the bundled abstract. Add `@flux_se.sylius_stripe.state_machine.stripe_state_applied_checker`
+(or any other `StripeStateAppliedCheckerInterface` implementation) as the sixth constructor argument.
+
 [link-sylius-stripe-app]: https://marketplace.stripe.com/apps/install/link/com.sylius.stripe

--- a/config/services/state_machine.yaml
+++ b/config/services/state_machine.yaml
@@ -1,5 +1,7 @@
 services:
-    
+    flux_se.sylius_stripe.state_machine.stripe_state_applied_checker:
+        class: FluxSE\SyliusStripePlugin\StateMachine\StripeStateAppliedChecker
+
     flux_se.sylius_stripe.state_machine.payment_state:
         abstract: true
         class: FluxSE\SyliusStripePlugin\StateMachine\PaymentStateProcessor
@@ -9,8 +11,9 @@ services:
             - '@sylius.factory.payment_request'
             - '@sylius.repository.payment_request'
             - '@sylius.announcer.payment_request'
+            - '@flux_se.sylius_stripe.state_machine.stripe_state_applied_checker'
             - '%flux_se.sylius_stripe.factories%'
-    
+
     flux_se.sylius_stripe.state_machine.refund:
         public: true
         parent: flux_se.sylius_stripe.state_machine.payment_state
@@ -18,7 +21,7 @@ services:
             - []
             - !php/const Sylius\Component\Payment\Model\PaymentInterface::STATE_REFUNDED
             - !php/const Sylius\Component\Payment\Model\PaymentRequestInterface::ACTION_REFUND
-    
+
     flux_se.sylius_stripe.state_machine.cancel:
         public: true
         parent: flux_se.sylius_stripe.state_machine.payment_state
@@ -27,8 +30,7 @@ services:
               1: !php/const Sylius\Component\Payment\Model\PaymentInterface::STATE_AUTHORIZED
             - !php/const Sylius\Component\Payment\Model\PaymentInterface::STATE_CANCELLED
             - !php/const Sylius\Component\Payment\Model\PaymentRequestInterface::ACTION_CANCEL
-        
-    
+
     flux_se.sylius_stripe.state_machine.capture_authorized:
         public: true
         parent: flux_se.sylius_stripe.state_machine.payment_state

--- a/src/StateMachine/PaymentStateProcessor.php
+++ b/src/StateMachine/PaymentStateProcessor.php
@@ -27,6 +27,7 @@ final readonly class PaymentStateProcessor implements PaymentStateProcessorInter
         private PaymentRequestFactoryInterface $paymentRequestFactory,
         private PaymentRequestRepositoryInterface $paymentRequestRepository,
         private PaymentRequestAnnouncerInterface $paymentRequestAnnouncer,
+        private StripeStateAppliedCheckerInterface $stripeStateAppliedChecker,
         private array $supportedFactories,
         private array $allowedPaymentFromStates,
         private string $requiredPaymentState,
@@ -65,6 +66,10 @@ final readonly class PaymentStateProcessor implements PaymentStateProcessorInter
                 $payment->getState(),
             ),
         );
+
+        if ($this->stripeStateAppliedChecker->isAlreadyApplied($payment, $this->paymentRequestAction)) {
+            return;
+        }
 
         $paymentRequest = $this->paymentRequestRepository->findOneByActionPaymentAndMethod(
             $this->paymentRequestAction,

--- a/src/StateMachine/StripeStateAppliedChecker.php
+++ b/src/StateMachine/StripeStateAppliedChecker.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\StateMachine;
+
+use Stripe\Checkout\Session;
+use Stripe\PaymentIntent;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class StripeStateAppliedChecker implements StripeStateAppliedCheckerInterface
+{
+    public function isAlreadyApplied(PaymentInterface $payment, string $paymentRequestAction): bool
+    {
+        $details = $payment->getDetails();
+        $object = $details['object'] ?? null;
+
+        if (PaymentIntent::OBJECT_NAME === $object) {
+            return $this->isPaymentIntentApplied($details, $paymentRequestAction);
+        }
+
+        if (Session::OBJECT_NAME === $object) {
+            return $this->isCheckoutSessionApplied($details, $paymentRequestAction);
+        }
+
+        return false;
+    }
+
+    /** @param array<string, mixed> $paymentIntent */
+    private function isPaymentIntentApplied(array $paymentIntent, string $paymentRequestAction): bool
+    {
+        $status = $paymentIntent['status'] ?? null;
+
+        return match ($paymentRequestAction) {
+            PaymentRequestInterface::ACTION_AUTHORIZE => PaymentIntent::STATUS_SUCCEEDED === $status,
+            PaymentRequestInterface::ACTION_CANCEL => PaymentIntent::STATUS_CANCELED === $status,
+            PaymentRequestInterface::ACTION_REFUND => $this->isLatestChargeRefunded($paymentIntent),
+            default => false,
+        };
+    }
+
+    /** @param array<string, mixed> $session */
+    private function isCheckoutSessionApplied(array $session, string $paymentRequestAction): bool
+    {
+        return match ($paymentRequestAction) {
+            PaymentRequestInterface::ACTION_AUTHORIZE => Session::PAYMENT_STATUS_PAID === ($session['payment_status'] ?? null),
+            PaymentRequestInterface::ACTION_CANCEL => $this->isCheckoutSessionCanceled($session),
+            PaymentRequestInterface::ACTION_REFUND => $this->isCheckoutSessionRefunded($session),
+            default => false,
+        };
+    }
+
+    /** @param array<string, mixed> $session */
+    private function isCheckoutSessionCanceled(array $session): bool
+    {
+        if (Session::STATUS_EXPIRED === ($session['status'] ?? null)) {
+            return true;
+        }
+
+        $paymentIntent = $session['payment_intent'] ?? null;
+        if (is_array($paymentIntent)) {
+            return PaymentIntent::STATUS_CANCELED === ($paymentIntent['status'] ?? null);
+        }
+
+        return false;
+    }
+
+    /** @param array<string, mixed> $session */
+    private function isCheckoutSessionRefunded(array $session): bool
+    {
+        $paymentIntent = $session['payment_intent'] ?? null;
+        if (!is_array($paymentIntent)) {
+            return false;
+        }
+
+        return $this->isLatestChargeRefunded($paymentIntent);
+    }
+
+    /** @param array<string, mixed> $paymentIntent */
+    private function isLatestChargeRefunded(array $paymentIntent): bool
+    {
+        $latestCharge = $paymentIntent['latest_charge'] ?? null;
+        if (!is_array($latestCharge)) {
+            return false;
+        }
+
+        return true === ($latestCharge['refunded'] ?? false);
+    }
+}

--- a/src/StateMachine/StripeStateAppliedCheckerInterface.php
+++ b/src/StateMachine/StripeStateAppliedCheckerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\StateMachine;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+interface StripeStateAppliedCheckerInterface
+{
+    public function isAlreadyApplied(PaymentInterface $payment, string $paymentRequestAction): bool;
+}

--- a/tests/Behat/Mocker/StripeWebElementsMocker.php
+++ b/tests/Behat/Mocker/StripeWebElementsMocker.php
@@ -72,12 +72,6 @@ final class StripeWebElementsMocker
     {
         // CaptureEnd
         $this->mockCancelPayment(PaymentIntent::CAPTURE_METHOD_AUTOMATIC);
-
-        // The Cancel workflow event is triggered
-        $this->paymentIntentMocker->mockRetrieveAction([
-            'status' => PaymentIntent::STATUS_CANCELED,
-            'capture_method' => PaymentIntent::CAPTURE_METHOD_AUTOMATIC,
-        ]);
     }
 
     public function mockSuccessfulPayment(): void

--- a/tests/Unit/StateMachine/PaymentStateProcessorTest.php
+++ b/tests/Unit/StateMachine/PaymentStateProcessorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\StateMachine;
+
+use FluxSE\SyliusStripePlugin\StateMachine\PaymentStateProcessor;
+use FluxSE\SyliusStripePlugin\StateMachine\StripeStateAppliedCheckerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\PaymentBundle\Announcer\PaymentRequestAnnouncerInterface;
+use Sylius\Bundle\PaymentBundle\Checker\FinalizedPaymentRequestCheckerInterface;
+use Sylius\Bundle\PaymentBundle\Provider\GatewayFactoryNameProviderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Payment\Factory\PaymentRequestFactoryInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
+
+final class PaymentStateProcessorTest extends TestCase
+{
+    private GatewayFactoryNameProviderInterface&MockObject $gatewayFactoryNameProvider;
+
+    private FinalizedPaymentRequestCheckerInterface&MockObject $finalizedPaymentRequestChecker;
+
+    /** @var PaymentRequestFactoryInterface<PaymentRequestInterface>&MockObject */
+    private PaymentRequestFactoryInterface&MockObject $paymentRequestFactory;
+
+    /** @var PaymentRequestRepositoryInterface<PaymentRequestInterface>&MockObject */
+    private PaymentRequestRepositoryInterface&MockObject $paymentRequestRepository;
+
+    private PaymentRequestAnnouncerInterface&MockObject $paymentRequestAnnouncer;
+
+    private StripeStateAppliedCheckerInterface&MockObject $stripeStateAppliedChecker;
+
+    protected function setUp(): void
+    {
+        $this->gatewayFactoryNameProvider = $this->createMock(GatewayFactoryNameProviderInterface::class);
+        $this->finalizedPaymentRequestChecker = $this->createMock(FinalizedPaymentRequestCheckerInterface::class);
+        $this->paymentRequestFactory = $this->createMock(PaymentRequestFactoryInterface::class);
+        $this->paymentRequestRepository = $this->createMock(PaymentRequestRepositoryInterface::class);
+        $this->paymentRequestAnnouncer = $this->createMock(PaymentRequestAnnouncerInterface::class);
+        $this->stripeStateAppliedChecker = $this->createMock(StripeStateAppliedCheckerInterface::class);
+    }
+
+    public function test_it_skips_dispatch_when_stripe_state_already_converged(): void
+    {
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getState')->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $this->gatewayFactoryNameProvider
+            ->method('provide')
+            ->with($paymentMethod)
+            ->willReturn('stripe_web_elements');
+
+        $this->stripeStateAppliedChecker
+            ->expects(self::once())
+            ->method('isAlreadyApplied')
+            ->with($payment, PaymentRequestInterface::ACTION_AUTHORIZE)
+            ->willReturn(true);
+
+        $this->paymentRequestRepository->expects(self::never())->method('findOneByActionPaymentAndMethod');
+        $this->paymentRequestFactory->expects(self::never())->method('create');
+        $this->paymentRequestRepository->expects(self::never())->method('add');
+        $this->paymentRequestAnnouncer->expects(self::never())->method('dispatchPaymentRequestCommand');
+
+        $processor = $this->buildProcessor();
+        $processor(payment: $payment, fromState: PaymentInterface::STATE_AUTHORIZED);
+    }
+
+    public function test_it_dispatches_when_stripe_state_has_not_converged(): void
+    {
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getState')->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $this->gatewayFactoryNameProvider
+            ->method('provide')
+            ->with($paymentMethod)
+            ->willReturn('stripe_web_elements');
+
+        $this->stripeStateAppliedChecker
+            ->expects(self::once())
+            ->method('isAlreadyApplied')
+            ->willReturn(false);
+
+        $newPaymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $newPaymentRequest->expects(self::once())->method('setAction')->with(PaymentRequestInterface::ACTION_AUTHORIZE);
+
+        $this->paymentRequestRepository
+            ->expects(self::once())
+            ->method('findOneByActionPaymentAndMethod')
+            ->willReturn(null);
+        $this->paymentRequestFactory
+            ->expects(self::once())
+            ->method('create')
+            ->with($payment, $paymentMethod)
+            ->willReturn($newPaymentRequest);
+        $this->paymentRequestRepository->expects(self::once())->method('add')->with($newPaymentRequest);
+        $this->paymentRequestAnnouncer
+            ->expects(self::once())
+            ->method('dispatchPaymentRequestCommand')
+            ->with($newPaymentRequest);
+
+        $processor = $this->buildProcessor();
+        $processor(payment: $payment, fromState: PaymentInterface::STATE_AUTHORIZED);
+    }
+
+    public function test_it_returns_early_when_from_state_is_not_allowed(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+
+        $this->stripeStateAppliedChecker->expects(self::never())->method('isAlreadyApplied');
+        $this->paymentRequestAnnouncer->expects(self::never())->method('dispatchPaymentRequestCommand');
+
+        $processor = $this->buildProcessor();
+        $processor(payment: $payment, fromState: PaymentInterface::STATE_NEW);
+    }
+
+    private function buildProcessor(): PaymentStateProcessor
+    {
+        return new PaymentStateProcessor(
+            $this->gatewayFactoryNameProvider,
+            $this->finalizedPaymentRequestChecker,
+            $this->paymentRequestFactory,
+            $this->paymentRequestRepository,
+            $this->paymentRequestAnnouncer,
+            $this->stripeStateAppliedChecker,
+            ['stripe_checkout', 'stripe_web_elements'],
+            [PaymentInterface::STATE_AUTHORIZED],
+            PaymentInterface::STATE_COMPLETED,
+            PaymentRequestInterface::ACTION_AUTHORIZE,
+        );
+    }
+}

--- a/tests/Unit/StateMachine/StripeStateAppliedCheckerTest.php
+++ b/tests/Unit/StateMachine/StripeStateAppliedCheckerTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\StateMachine;
+
+use FluxSE\SyliusStripePlugin\StateMachine\StripeStateAppliedChecker;
+use PHPUnit\Framework\TestCase;
+use Stripe\Checkout\Session;
+use Stripe\PaymentIntent;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class StripeStateAppliedCheckerTest extends TestCase
+{
+    private StripeStateAppliedChecker $checker;
+
+    protected function setUp(): void
+    {
+        $this->checker = new StripeStateAppliedChecker();
+    }
+
+    public function test_it_returns_false_when_details_are_empty(): void
+    {
+        $payment = $this->paymentWithDetails([]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_AUTHORIZE));
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_CANCEL));
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_REFUND));
+    }
+
+    public function test_it_returns_false_for_unknown_object_shape(): void
+    {
+        $payment = $this->paymentWithDetails(['object' => 'something_else', 'status' => 'succeeded']);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_AUTHORIZE));
+    }
+
+    public function test_it_returns_false_for_unknown_action(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+        ]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, 'unknown_action'));
+    }
+
+    public function test_payment_intent_authorize_converges_when_status_is_succeeded(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_AUTHORIZE));
+    }
+
+    public function test_payment_intent_authorize_does_not_converge_while_requires_capture(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_REQUIRES_CAPTURE,
+        ]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_AUTHORIZE));
+    }
+
+    public function test_payment_intent_cancel_converges_when_status_is_canceled(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_CANCELED,
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_CANCEL));
+    }
+
+    public function test_payment_intent_refund_converges_when_latest_charge_is_refunded(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'latest_charge' => ['refunded' => true],
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_REFUND));
+    }
+
+    public function test_payment_intent_refund_does_not_converge_when_latest_charge_is_not_refunded(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'latest_charge' => ['refunded' => false],
+        ]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_REFUND));
+    }
+
+    public function test_payment_intent_refund_does_not_converge_when_latest_charge_is_not_expanded(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'latest_charge' => 'ch_abc',
+        ]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_REFUND));
+    }
+
+    public function test_checkout_session_authorize_converges_when_payment_status_is_paid(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => Session::OBJECT_NAME,
+            'payment_status' => Session::PAYMENT_STATUS_PAID,
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_AUTHORIZE));
+    }
+
+    public function test_checkout_session_authorize_does_not_converge_while_unpaid(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => Session::OBJECT_NAME,
+            'payment_status' => Session::PAYMENT_STATUS_UNPAID,
+        ]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_AUTHORIZE));
+    }
+
+    public function test_checkout_session_cancel_converges_when_session_is_expired(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => Session::OBJECT_NAME,
+            'status' => Session::STATUS_EXPIRED,
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_CANCEL));
+    }
+
+    public function test_checkout_session_cancel_converges_when_nested_payment_intent_is_canceled(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => Session::OBJECT_NAME,
+            'status' => Session::STATUS_OPEN,
+            'payment_intent' => ['status' => PaymentIntent::STATUS_CANCELED],
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_CANCEL));
+    }
+
+    public function test_checkout_session_refund_converges_when_nested_charge_is_refunded(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => Session::OBJECT_NAME,
+            'payment_status' => Session::PAYMENT_STATUS_PAID,
+            'payment_intent' => [
+                'status' => PaymentIntent::STATUS_SUCCEEDED,
+                'latest_charge' => ['refunded' => true],
+            ],
+        ]);
+
+        self::assertTrue($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_REFUND));
+    }
+
+    public function test_checkout_session_refund_does_not_converge_without_nested_payment_intent(): void
+    {
+        $payment = $this->paymentWithDetails([
+            'object' => Session::OBJECT_NAME,
+            'payment_status' => Session::PAYMENT_STATUS_PAID,
+        ]);
+
+        self::assertFalse($this->checker->isAlreadyApplied($payment, PaymentRequestInterface::ACTION_REFUND));
+    }
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    private function paymentWithDetails(array $details): PaymentInterface
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getDetails')->willReturn($details);
+
+        return $payment;
+    }
+}


### PR DESCRIPTION
### Summary

After an `Authorized → Completed` transition driven by a Stripe webhook (e.g. admin captures the authorization in the Stripe Dashboard), `PaymentCompletedStateListener` was unconditionally dispatching another `action=AUTHORIZE` PaymentRequest. The follow-up handler did not recognize the PaymentIntent as still capturable (status was already `succeeded`), fell through to the "create new PaymentIntent" branch, and overwrote `Payment.details` with a fresh, empty PI # 2 (Incomplete, no Charge).

### Fix

Introduce `StripeStateAppliedCheckerInterface` and inspect `Payment.details` in `PaymentStateProcessor` before creating/dispatching a follow-up PaymentRequest. If the underlying Stripe object (PaymentIntent or Checkout Session) already reflects the action's effect (`status=succeeded` / `status=canceled` / `latest_charge.refunded=true`), the processor returns early.

The check makes the listener **idempotent with respect to the transition source** — admin-driven transitions (designed path, e.g. Sylius admin "Complete" on Authorized) still trigger the Stripe API call, but webhook-driven transitions no longer cause a duplicate side-effect.