### PR TITLE
Propagate token_hash on PaymentIntent metadata of Checkout Session for webhook resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,24 +127,29 @@ Then create a new endpoint with those events:
 
 | Gateway | `stripe_checkout` | `stripe_web_elements` |
 |-|-|-|
-| Webhook events |  - `checkout.session.completed`<br> - `checkout.session.async_payment_failed`<br> - `checkout.session.async_payment_succeeded`<br> - `checkout.session.expired`<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |  - `payment_intent.canceled`<br> - `payment_intent.succeeded`<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |
+| Webhook events |  - `checkout.session.completed`<br> - `checkout.session.async_payment_failed`<br> - `checkout.session.async_payment_succeeded`<br> - `checkout.session.expired`<br> - `payment_intent.succeeded` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `payment_intent.canceled` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `payment_intent.processing` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |  - `payment_intent.canceled`<br> - `payment_intent.succeeded`<br> - `payment_intent.processing`<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |
 
-> 💡 **Express Checkout on the cart page** (`enable_express_checkout` toggle on) always
-> creates a PaymentIntent on Stripe regardless of the gateway type. If you enable it on
-> a `stripe_checkout` PaymentMethod, **add these events to that endpoint** in addition
-> to the `checkout.session.*` ones listed above:
-> - `payment_intent.succeeded`
-> - `payment_intent.canceled`
-> - `payment_intent.processing`
+> 💡 **`payment_intent.*` for `stripe_checkout`.** The three `payment_intent.*` events
+> are required on a `stripe_checkout` PaymentMethod endpoint whenever **at least one** of
+> the following is true:
+>
+> - **`use authorize` is ON** — needed so Stripe Dashboard capture/cancel of the
+>   authorized PaymentIntent syncs back to Sylius, and so the webhook acts as a fallback
+>   when a Sylius admin action on an Authorized order can't reach Stripe directly.
+> - **Express Checkout on the cart page** (`enable_express_checkout` toggle on) — ECE
+>   always creates a PaymentIntent on Stripe regardless of the gateway type. See
+>   [Express Checkout on the cart page](docs/EXPRESS-CHECKOUT.md) for the full setup
+>   (domain registration, wallet activation, local testing).
+>
+> Without these events Sylius silently misses the corresponding state transitions
+> (e.g. Authorized → Paid after Dashboard capture).
 >
 > For `stripe_web_elements` the same `payment_intent.*` events are already required by
-> the regular flow — no extra subscription is needed when the toggle is on.
+> the regular flow — `use authorize` and the ECE toggle do not change that list.
 >
-> See [Express Checkout on the cart page](docs/EXPRESS-CHECKOUT.md) for the full setup
-> (domain registration, wallet activation, local testing). Which wallets actually appear
-> on the button (Apple Pay, Google Pay, Link, PayPal, Amazon Pay) is decided by your
-> Stripe Dashboard configuration and the customer's browser — the plugin does not
-> hard-code that list.
+> Which wallets actually appear on the Express Checkout button (Apple Pay, Google Pay,
+> Link, PayPal, Amazon Pay) is decided by your Stripe Dashboard configuration and the
+> customer's browser — the plugin does not hard-code that list.
 
 The URL to fill is the route named `sylius_payment_method_notify` with the `{code}`
 param equal to the `payment method code`, here is an example :
@@ -178,7 +183,8 @@ stripe login
 
 Then start to listen for the Stripe events (minimal ones are used here), forwarding request to your local server :
 
- 1. Example with `my_shop_stripe_checkout` as payment method code:
+ 1. Example with `my_shop_stripe_checkout` as payment method code
+    (regular Checkout flow, `use authorize` OFF, Express Checkout OFF):
     ```shell
     stripe listen \
        --events checkout.session.completed,checkout.session.async_payment_failed,checkout.session.async_payment_succeeded,checkout.session.expired \
@@ -188,12 +194,13 @@ Then start to listen for the Stripe events (minimal ones are used here), forward
  2. Example with `my_shop_stripe_web_elements` as payment method code:
     ```shell
     stripe listen \
-       --events payment_intent.canceled,payment_intent.succeeded \
+       --events payment_intent.canceled,payment_intent.succeeded,payment_intent.processing \
        --forward-to https://localhost/payment-methods/my_shop_stripe_web_elements
     ```
- 3. Example with `my_shop_stripe_checkout` as payment method code **and Express Checkout enabled**
-    (merges the `checkout.session.*` events of the regular flow with the `payment_intent.*`
-    events emitted by the cart-page wallet flow):
+ 3. Example with `my_shop_stripe_checkout` as payment method code **with `use authorize`
+    ON or Express Checkout enabled** (adds the `payment_intent.*` events on top of the
+    `checkout.session.*` ones — needed so Stripe Dashboard capture/cancel sync back to
+    Sylius and so the cart-page wallet flow can complete):
     ```shell
     stripe listen \
        --events checkout.session.completed,checkout.session.async_payment_failed,checkout.session.async_payment_succeeded,checkout.session.expired,payment_intent.succeeded,payment_intent.canceled,payment_intent.processing \

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -293,4 +293,36 @@ Sylius test attributes referenced inside these templates (`config-publishable-ke
 If you registered hooks at any of the old priorities to slot a custom field between existing ones, recompute against
 the new scheme (step 50).
 
+## `payment_intent.*` webhook events required for `stripe_checkout` with `use authorize`
+
+In 2.0 the Checkout Session creation request propagates the Sylius `PaymentRequest` `token_hash` into 
+`payment_intent_data.metadata` (and therefore onto the resulting `PaymentIntent` and `Charge`). Before this change, 
+`payment_intent.*` events emitted by a `stripe_checkout` PaymentIntent were unresolvable by the plugin (the resolver 
+looks the `PaymentRequest` up by `metadata.token_hash`) and returned HTTP 500.
+
+As a consequence, **Stripe Dashboard-side capture and cancel of an authorized PaymentIntent now synchronize back to 
+Sylius via webhooks** — which means the Stripe webhook endpoint of every `stripe_checkout` PaymentMethod with 
+`use authorize` ON must subscribe to:
+
+- `payment_intent.succeeded`
+- `payment_intent.canceled`
+- `payment_intent.processing`
+
+These are the same three events the Express Checkout migration already requires (see the section above) — if you applied 
+that migration on a PaymentMethod with `use authorize` ON, you are already done; the events are needed regardless of 
+whether the ECE toggle is on.
+
+Without these events the following stops working:
+
+- Capturing the authorized PaymentIntent in the Stripe Dashboard leaves the order stuck in `Authorized` while the money 
+  is already taken (Sylius / Stripe state mismatch).
+- Cancelling the authorized PaymentIntent in the Stripe Dashboard does not propagate to Sylius (Payment stays
+  `Authorized`).
+- The webhook can no longer act as a fallback when a Sylius admin "Complete" / "Cancel" action on an Authorized order 
+  fails mid-flight (the Stripe API call may have already succeeded by then).
+
+**Migration:** for every existing `stripe_checkout` PaymentMethod with `use authorize` ON, open the matching webhook 
+endpoint in the Stripe Dashboard and add the three events above. The [`docs/WEBHOOK-EVENTS.md`](docs/WEBHOOK-EVENTS.md) 
+file has the full per-gateway / per-mode matrix.
+
 [link-sylius-stripe-app]: https://marketplace.stripe.com/apps/install/link/com.sylius.stripe

--- a/config/services/providers/checkout/create_params_providers.yaml
+++ b/config/services/providers/checkout/create_params_providers.yaml
@@ -92,6 +92,12 @@ services:
             - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata
               priority: -200
 
+    flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata.token_hash:
+        class: FluxSE\SyliusStripePlugin\Provider\TokenHashMetadataProvider
+        tags:
+            - name: flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata
+              priority: -250
+
     flux_se.sylius_stripe.provider.checkout.create.line_items:
         class: FluxSE\SyliusStripePlugin\Provider\Checkout\Create\LineItemsProvider
         arguments:

--- a/docs/WEBHOOK-EVENTS.md
+++ b/docs/WEBHOOK-EVENTS.md
@@ -8,6 +8,35 @@ This plugin will be able to listen to webhook events which are related to a Syli
 If you want to listen to other events, you will have to create your own route and controller.
 However, you will be able to use services provided by this plugin to handle and verify the Stripe events.
 
+## Required Stripe events per gateway and mode
+
+The events your Stripe webhook endpoint must subscribe to depend on the gateway type, the `use authorize` flag, and on
+whether Express Checkout (ECE) on the cart page is enabled.
+
+| Gateway | `use authorize` | Express Checkout | Required events |
+|---|:-:|:-:|---|
+| `stripe_checkout` | OFF | OFF | `checkout.session.completed`, `checkout.session.expired`, `checkout.session.async_payment_failed`, `checkout.session.async_payment_succeeded` |
+| `stripe_checkout` | **ON** | OFF | the four `checkout.session.*` above **and** `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.processing` |
+| `stripe_checkout` | OFF | **ON** | the four `checkout.session.*` above **and** `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.processing` |
+| `stripe_checkout` | **ON** | **ON** | the four `checkout.session.*` above **and** `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.processing` |
+| `stripe_web_elements` | any | any | `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.processing` |
+| any using `setup` mode | — | — | add `setup_intent.succeeded`, `setup_intent.canceled` on top of the rows above |
+
+Why the `payment_intent.*` events matter for `stripe_checkout`:
+
+- **`use authorize` ON** — when a merchant captures or cancels the authorized PaymentIntent directly in the Stripe
+  Dashboard (instead of via the Sylius admin), only a `payment_intent.*` event is emitted. Without subscribing to it,
+  Sylius never learns about the Dashboard-side change and the order is left stuck in `Authorized` indefinitely.
+- **`use authorize` ON** also lets the webhook act as a fallback for the Sylius admin "Complete" / "Cancel" actions —
+  the admin action itself can fail mid-flight while the Stripe API call already succeeded; the matching
+  `payment_intent.*` event rescues the order state in that case.
+- **Express Checkout on the cart page** always creates a PaymentIntent (never a Checkout Session), regardless of the
+  gateway type. See [Express Checkout](EXPRESS-CHECKOUT.md) for the full feature description.
+
+> 💡 Subscribing to the three `payment_intent.*` events on a `stripe_checkout` endpoint is harmless even when neither
+> flag is on — the plugin resolves each event against the Sylius `PaymentRequest` via the `token_hash` metadata and
+> returns 2xx without state changes if there is nothing to transition.
+
 ## How are webhook events listened to using this plugin?
 Here is how the Sylius `PaymentRequest` notify process is working:
 

--- a/tests/Functional/Provider/Checkout/Create/DetailsProviderTest.php
+++ b/tests/Functional/Provider/Checkout/Create/DetailsProviderTest.php
@@ -89,6 +89,7 @@ class DetailsProviderTest extends KernelTestCase
         $paymentRequest = $fixtures[$paymentRequestName];
 
         $expectedDetails['metadata']['token_hash'] = $paymentRequest->getId();
+        $expectedDetails['payment_intent_data']['metadata']['token_hash'] = $paymentRequest->getId();
         if (null === $paymentRequest->getPayload()) {
             // Using Shop UI, the locale context is given by the current request context, here we forced it.
             $locale = 'en_US';


### PR DESCRIPTION
### Summary

`payment_intent.*` webhook events emitted for a `stripe_checkout` PaymentMethod returned HTTP 500 because the PaymentIntent (and its Charge) created by the Checkout Session did not carry `metadata.token_hash`. `StripeNotifyPaymentProvider` resolves the matching Sylius `PaymentRequest` by that key and threw `LogicException` when absent.

This blocked:

- Stripe Dashboard capture/cancel of an authorized PaymentIntent syncing back to Sylius — order stuck in `Authorized` while the money is already taken.
- The webhook acting as a fallback for failing Sylius admin "Complete"/"Cancel" actions on Authorized orders.
- Normal Checkout payments emitted a redundant `[500] payment_intent.succeeded` on every transaction — the order itself completes via `checkout.session.completed`, but Stripe retries the 500.

### Root cause

`TokenHashMetadataProvider` was tagged for the Checkout Session **Session-level** metadata only, not for `payment_intent_data.metadata`. Stripe propagates `payment_intent_data.metadata` onto the resulting `PaymentIntent` and `Charge`, so without the tag the PI/Charge ended up without `token_hash`. Web Elements does not have this gap — the equivalent tag for its PaymentIntent metadata already includes `TokenHashMetadataProvider`.

### Fix

DI-only change in `config/services/providers/checkout/create_params_providers.yaml`: register the existing `TokenHashMetadataProvider` under `flux_se.sylius_stripe.provider.checkout.create.payment_intent_data.metadata`. Zero PHP changes — the same service that already handles Session metadata and Web Elements PaymentIntent metadata is reused. After the fix every Checkout-Session-created PaymentIntent carries `token_hash` in metadata, so `payment_intent.*` events resolve and processing follows the same path Web Elements already takes.