### PR TITLE
Handle charge.refunded webhook to sync Stripe Dashboard refunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Then create a new endpoint with those events:
 
 | Gateway | `stripe_checkout` | `stripe_web_elements` |
 |-|-|-|
-| Webhook events |  - `checkout.session.completed`<br> - `checkout.session.async_payment_failed`<br> - `checkout.session.async_payment_succeeded`<br> - `checkout.session.expired`<br> - `payment_intent.succeeded` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `payment_intent.canceled` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `payment_intent.processing` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |  - `payment_intent.canceled`<br> - `payment_intent.succeeded`<br> - `payment_intent.processing`<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |
+| Webhook events |  - `checkout.session.completed`<br> - `checkout.session.async_payment_failed`<br> - `checkout.session.async_payment_succeeded`<br> - `checkout.session.expired`<br> - `payment_intent.succeeded` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `payment_intent.canceled` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `payment_intent.processing` (⚠️ Required when `use authorize` is ON or Express Checkout is enabled — see note below)<br> - `charge.refunded` (⚠️ Only needed to sync refunds initiated from the Stripe Dashboard)<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |  - `payment_intent.canceled`<br> - `payment_intent.succeeded`<br> - `payment_intent.processing`<br> - `charge.refunded` (⚠️ Only needed to sync refunds initiated from the Stripe Dashboard)<br> - `setup_intent.canceled` (⚠️ Only when using `setup` mode)<br> - `setup_intent.succeeded`  (⚠️ Only when using `setup` mode) |
 
 > 💡 **`payment_intent.*` for `stripe_checkout`.** The three `payment_intent.*` events
 > are required on a `stripe_checkout` PaymentMethod endpoint whenever **at least one** of
@@ -150,6 +150,12 @@ Then create a new endpoint with those events:
 > Which wallets actually appear on the Express Checkout button (Apple Pay, Google Pay,
 > Link, PayPal, Amazon Pay) is decided by your Stripe Dashboard configuration and the
 > customer's browser — the plugin does not hard-code that list.
+
+> 💡 **`charge.refunded` for Dashboard refunds.** A refund made from the Sylius admin does
+> not need a webhook. Subscribe to `charge.refunded` (on either gateway) only if refunds may
+> be initiated directly in the Stripe Dashboard — it lets Sylius move a **fully** refunded
+> payment to `Refunded`. A **partial** refund has no native Sylius state, so the plugin leaves
+> the payment unchanged. See [Webhook events](docs/WEBHOOK-EVENTS.md) for details.
 
 The URL to fill is the route named `sylius_payment_method_notify` with the `{code}`
 param equal to the `payment method code`, here is an example :
@@ -191,10 +197,11 @@ Then start to listen for the Stripe events (minimal ones are used here), forward
        --forward-to https://localhost/payment-methods/my_shop_stripe_checkout
     ```
 
- 2. Example with `my_shop_stripe_web_elements` as payment method code:
+ 2. Example with `my_shop_stripe_web_elements` as payment method code
+    (append `charge.refunded` to also sync refunds initiated from the Stripe Dashboard):
     ```shell
     stripe listen \
-       --events payment_intent.canceled,payment_intent.succeeded,payment_intent.processing \
+       --events payment_intent.canceled,payment_intent.succeeded,payment_intent.processing,charge.refunded \
        --forward-to https://localhost/payment-methods/my_shop_stripe_web_elements
     ```
  3. Example with `my_shop_stripe_checkout` as payment method code **with `use authorize`
@@ -203,9 +210,12 @@ Then start to listen for the Stripe events (minimal ones are used here), forward
     Sylius and so the cart-page wallet flow can complete):
     ```shell
     stripe listen \
-       --events checkout.session.completed,checkout.session.async_payment_failed,checkout.session.async_payment_succeeded,checkout.session.expired,payment_intent.succeeded,payment_intent.canceled,payment_intent.processing \
+       --events checkout.session.completed,checkout.session.async_payment_failed,checkout.session.async_payment_succeeded,checkout.session.expired,payment_intent.succeeded,payment_intent.canceled,payment_intent.processing,charge.refunded \
        --forward-to https://localhost/payment-methods/my_shop_stripe_checkout
     ```
+
+> 💡 Add `,charge.refunded` to any of the `--events` lists above to also sync refunds that are
+> initiated from the Stripe Dashboard (full refund → payment `Refunded`; partial refund is a no-op).
 
 > 💡 Replace --forward-to argument value with the right one you need.
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -386,4 +386,15 @@ The new service is wired automatically through the bundled service definition
 definition that does **not** use the bundled one. Add
 `@FluxSE\SyliusStripePlugin\Appearance\AppearanceBuilder` as the third constructor argument.
 
+## `StripeNotifyPaymentProvider` constructor signature changed
+
+`FluxSE\SyliusStripePlugin\Provider\StripeNotifyPaymentProvider` gained a new constructor argument
+`RefundEventTokenHashResolverInterface $refundEventTokenHashResolver`, appended after the existing
+`EventResolverInterface $eventResolver` argument.
+
+**You must migrate if** you instantiate `StripeNotifyPaymentProvider` directly in PHP or via a manual service
+definition that does **not** use the bundled one. Add
+`@flux_se.sylius_stripe.provider.refund_event_token_hash_resolver` (or any other
+`RefundEventTokenHashResolverInterface` implementation) as the fourth constructor argument.
+
 [link-sylius-stripe-app]: https://marketplace.stripe.com/apps/install/link/com.sylius.stripe

--- a/config/services/processors.yaml
+++ b/config/services/processors.yaml
@@ -14,6 +14,11 @@ parameters:
             - !php/const Stripe\Event::PAYMENT_INTENT_SUCCEEDED
             - !php/const Stripe\Event::PAYMENT_INTENT_CANCELED
             - !php/const Stripe\Event::PAYMENT_INTENT_PROCESSING
+    flux_se.sylius_stripe.processor.webhook_event.charge_refunded:
+        'stripe_web_elements':
+            - !php/const Stripe\Event::CHARGE_REFUNDED
+        'stripe_checkout':
+            - !php/const Stripe\Event::CHARGE_REFUNDED
 
 services:
     
@@ -64,6 +69,18 @@ services:
             # Express Checkout on cart always creates a PaymentIntent. When the merchant enables
             # ECE on a stripe_checkout PaymentMethod, payment_intent.* webhooks land on that
             # method's URL too — reuse the same processor here.
+            - name: flux_se.sylius_stripe.processor.webhook_event.checkout
+
+    flux_se.sylius_stripe.processor.webhook_event.charge_refunded:
+        class: FluxSE\SyliusStripePlugin\Processor\ChargeRefundedWebhookEventProcessor
+        arguments:
+            - '%flux_se.sylius_stripe.processor.webhook_event.charge_refunded%'
+            # A "charge.refunded" event only references a PaymentIntent id, so we retrieve the
+            # PaymentIntent (with "latest_charge" expanded) regardless of the gateway factory.
+            - '@flux_se.sylius_stripe.manager.web_elements.retrieve'
+            - '@logger'
+        tags:
+            - name: flux_se.sylius_stripe.processor.webhook_event.web_elements
             - name: flux_se.sylius_stripe.processor.webhook_event.checkout
 
     flux_se.sylius_stripe.processor.payment_transition.checkout.composite:

--- a/config/services/providers.yaml
+++ b/config/services/providers.yaml
@@ -15,8 +15,15 @@ services:
             - '%flux_se.sylius_stripe.factories%'
             - '@sylius.repository.payment_request'
             - '@flux_se.sylius_stripe.stripe.resolver.event_resolver'
+            - '@flux_se.sylius_stripe.provider.refund_event_token_hash_resolver'
         tags:
             - name: sylius.payment_request.payment_notify_provider
+
+    flux_se.sylius_stripe.provider.refund_event_token_hash_resolver:
+        class: FluxSE\SyliusStripePlugin\Provider\RefundEventTokenHashResolver
+        arguments:
+            - '@flux_se.sylius_stripe.stripe.factory.client'
+    FluxSE\SyliusStripePlugin\Provider\RefundEventTokenHashResolverInterface: '@flux_se.sylius_stripe.provider.refund_event_token_hash_resolver'
 
     flux_se.sylius_stripe.processor.transition.checkout.session:
         class: FluxSE\SyliusStripePlugin\Provider\Transition\Checkout\SessionTransitionProvider

--- a/docs/WEBHOOK-EVENTS.md
+++ b/docs/WEBHOOK-EVENTS.md
@@ -21,6 +21,7 @@ whether Express Checkout (ECE) on the cart page is enabled.
 | `stripe_checkout` | **ON** | **ON** | the four `checkout.session.*` above **and** `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.processing` |
 | `stripe_web_elements` | any | any | `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.processing` |
 | any using `setup` mode | — | — | add `setup_intent.succeeded`, `setup_intent.canceled` on top of the rows above |
+| any (both gateways) | — | — | add `charge.refunded` **only if** refunds are initiated from the Stripe Dashboard (see below) |
 
 Why the `payment_intent.*` events matter for `stripe_checkout`:
 
@@ -36,6 +37,21 @@ Why the `payment_intent.*` events matter for `stripe_checkout`:
 > 💡 Subscribing to the three `payment_intent.*` events on a `stripe_checkout` endpoint is harmless even when neither
 > flag is on — the plugin resolves each event against the Sylius `PaymentRequest` via the `token_hash` metadata and
 > returns 2xx without state changes if there is nothing to transition.
+
+### Refunds initiated from the Stripe Dashboard (`charge.refunded`)
+
+A refund made through the Sylius admin does **not** need a webhook — the plugin updates the payment state directly.
+The `charge.refunded` event is only required when a refund is triggered **from the Stripe Dashboard** (or the Stripe
+API) so that Sylius learns about it. It works for both gateways.
+
+- **Full refund** (`charge.refunded === true`) → the `Payment` transitions `completed → refunded`.
+- **Partial refund** (`charge.refunded === false`, `amount_refunded > 0`) → Sylius has no native "partially refunded"
+  payment state, so the plugin intentionally leaves the state unchanged (it logs an `info` message and returns 2xx).
+
+Resolution detail: the `charge.refunded` event object is a `Charge`, which carries **no** `token_hash` metadata
+(Stripe does not copy PaymentIntent metadata onto the Charge). The plugin therefore reads `charge.payment_intent` and
+re-fetches the related PaymentIntent to read its `token_hash` (see `StripeNotifyPaymentProvider` /
+`RefundEventTokenHashResolver`), then drives the refund through `ChargeRefundedWebhookEventProcessor`.
 
 ## How are webhook events listened to using this plugin?
 Here is how the Sylius `PaymentRequest` notify process is working:
@@ -75,6 +91,10 @@ Finally, when the `NotifyPaymentRequest` command is handled, the `NotifyPaymentR
 ## How to listen to `Payment related` Stripe events?
 
 When the event already contains a `data.object.metadata.token_hash` key and the value is an existing `PaymentRequest` hash.
+
+> When the event object itself has no `token_hash` (e.g. a `Charge` from `charge.refunded`) but references a
+> PaymentIntent, the plugin resolves it by re-fetching that PaymentIntent — see the
+> [Refunds initiated from the Stripe Dashboard](#refunds-initiated-from-the-stripe-dashboard-chargerefunded) section.
 
 > If it's not the case, go to the next chapter [to listen to `NON Payment related` Stripe events](#how-to-listen-to-non-payment-related-stripe-events).
 

--- a/src/Processor/ChargeRefundedWebhookEventProcessor.php
+++ b/src/Processor/ChargeRefundedWebhookEventProcessor.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Processor;
+
+use FluxSE\SyliusStripePlugin\Manager\RetrieveManagerInterface;
+use Psr\Log\LoggerInterface;
+use Stripe\ApiResource;
+use Stripe\Event;
+use Stripe\StripeObject;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * Handles "charge.refunded" events (refunds initiated from the Stripe Dashboard). The event object is
+ * a Charge, so we retrieve its related PaymentIntent (with "latest_charge" expanded) and store it on the
+ * payment details. The PaymentIntent transition processor then drives the "completed -> refunded" transition
+ * for a full refund. A partial refund leaves "charge.refunded" false, so no transition is applied.
+ */
+final readonly class ChargeRefundedWebhookEventProcessor implements WebhookEventProcessorInterface
+{
+    /**
+     * @param array<string, string[]> $supportedFactoriesAndEvents
+     * @param RetrieveManagerInterface<ApiResource> $retrieveManager
+     */
+    public function __construct(
+        private array $supportedFactoriesAndEvents,
+        private RetrieveManagerInterface $retrieveManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function process(PaymentRequestInterface $paymentRequest, Event $event): void
+    {
+        /** @var StripeObject|null $object */
+        $object = $event->data->object;
+        Assert::isInstanceOf(
+            $object,
+            StripeObject::class,
+            'The Stripe event data object must be an instance of StripeObject.',
+        );
+
+        $paymentIntentId = $object->offsetGet('payment_intent');
+        if (false === is_string($paymentIntentId) || '' === $paymentIntentId) {
+            return;
+        }
+
+        $this->logPartialRefund($paymentRequest, $object);
+
+        $stripeApiResource = $this->retrieveManager->retrieve($paymentRequest, $paymentIntentId);
+
+        $paymentRequest->getPayment()->setDetails($stripeApiResource->toArray());
+    }
+
+    public function supports(PaymentRequestInterface $paymentRequest, Event $event): bool
+    {
+        $factoryName = $paymentRequest->getMethod()->getGatewayConfig()?->getFactoryName() ?? '';
+        if (false === array_key_exists($factoryName, $this->supportedFactoriesAndEvents)) {
+            return false;
+        }
+
+        return in_array($event->type, $this->supportedFactoriesAndEvents[$factoryName], true);
+    }
+
+    private function logPartialRefund(PaymentRequestInterface $paymentRequest, StripeObject $charge): void
+    {
+        if (true === $charge->offsetGet('refunded')) {
+            return;
+        }
+
+        $amountRefunded = $charge->offsetGet('amount_refunded');
+        if (false === is_int($amountRefunded) || $amountRefunded <= 0) {
+            return;
+        }
+
+        $this->logger->info(sprintf(
+            'Stripe partial refund (amount: %d) received for payment "%s". Sylius has no partial-refund state, so no payment transition was applied.',
+            $amountRefunded,
+            (string) $paymentRequest->getPayment()->getId(),
+        ));
+    }
+}

--- a/src/Provider/RefundEventTokenHashResolver.php
+++ b/src/Provider/RefundEventTokenHashResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Provider;
+
+use ArrayAccess;
+use FluxSE\SyliusStripePlugin\Stripe\Factory\ClientFactoryInterface;
+use Stripe\StripeObject;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+
+final readonly class RefundEventTokenHashResolver implements RefundEventTokenHashResolverInterface
+{
+    public function __construct(
+        private ClientFactoryInterface $clientFactory,
+    ) {
+    }
+
+    public function resolve(StripeObject $object, PaymentMethodInterface $paymentMethod): ?string
+    {
+        $paymentIntentId = $object->offsetGet('payment_intent');
+        if (false === is_string($paymentIntentId) || '' === $paymentIntentId) {
+            return null;
+        }
+
+        $stripeClient = $this->clientFactory->createFromPaymentMethod($paymentMethod);
+        $paymentIntent = $stripeClient->paymentIntents->retrieve($paymentIntentId);
+
+        /** @var ArrayAccess<string, string>|null $metadata */
+        $metadata = $paymentIntent->metadata;
+        if (false === $metadata instanceof ArrayAccess) {
+            return null;
+        }
+
+        $hash = $metadata->offsetGet(MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME);
+
+        return is_string($hash) ? $hash : null;
+    }
+}

--- a/src/Provider/RefundEventTokenHashResolverInterface.php
+++ b/src/Provider/RefundEventTokenHashResolverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Provider;
+
+use Stripe\StripeObject;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+
+interface RefundEventTokenHashResolverInterface
+{
+    /**
+     * Resolves the token hash for a Stripe event object that does not carry it in its own metadata
+     * (e.g. a Charge from a "charge.refunded" event) by reading it from the related PaymentIntent.
+     */
+    public function resolve(StripeObject $object, PaymentMethodInterface $paymentMethod): ?string;
+}

--- a/src/Provider/StripeNotifyPaymentProvider.php
+++ b/src/Provider/StripeNotifyPaymentProvider.php
@@ -24,6 +24,7 @@ final readonly class StripeNotifyPaymentProvider implements NotifyPaymentProvide
         private array $supportedFactories,
         private PaymentRequestRepositoryInterface $paymentRequestRepository,
         private EventResolverInterface $eventResolver,
+        private RefundEventTokenHashResolverInterface $refundEventTokenHashResolver,
     ) {
     }
 
@@ -43,17 +44,12 @@ final readonly class StripeNotifyPaymentProvider implements NotifyPaymentProvide
             throw new \LogicException('The Stripe event data object is not a StripeObject.');
         }
 
-        /** @var ArrayAccess<string, string>|null $metadata */
-        $metadata = $object->offsetGet('metadata');
-        if (false === $metadata instanceof ArrayAccess) {
-            throw new \LogicException('The Stripe event metadata is not an \ArrayAccess.');
-        }
-
-        $hash = $metadata->offsetGet(MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME);
+        $hash = $this->resolveTokenHash($object, $paymentMethod);
         if (!is_string($hash)) {
             throw new \LogicException(sprintf(
-                'The Stripe event object metadata (key: "%s") must be a string.',
+                'Unable to resolve the token hash (key: "%s") for this Stripe event (ID:"%s").',
                 MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME,
+                $event->id,
             ));
         }
 
@@ -69,6 +65,24 @@ final readonly class StripeNotifyPaymentProvider implements NotifyPaymentProvide
         }
 
         return $paymentRequest->getPayment();
+    }
+
+    /**
+     * Reads the token hash from the event object metadata. Refund events (e.g. "charge.refunded")
+     * carry a Charge whose metadata has no token hash, so we fall back to the related PaymentIntent.
+     */
+    private function resolveTokenHash(StripeObject $object, PaymentMethodInterface $paymentMethod): ?string
+    {
+        /** @var ArrayAccess<string, string>|null $metadata */
+        $metadata = $object->offsetGet('metadata');
+        if ($metadata instanceof ArrayAccess) {
+            $hash = $metadata->offsetGet(MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME);
+            if (is_string($hash)) {
+                return $hash;
+            }
+        }
+
+        return $this->refundEventTokenHashResolver->resolve($object, $paymentMethod);
     }
 
     public function supports(Request $request, PaymentMethodInterface $paymentMethod): bool

--- a/tests/Unit/Processor/ChargeRefundedWebhookEventProcessorTest.php
+++ b/tests/Unit/Processor/ChargeRefundedWebhookEventProcessorTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Processor;
+
+use FluxSE\SyliusStripePlugin\Manager\RetrieveManagerInterface;
+use FluxSE\SyliusStripePlugin\Processor\ChargeRefundedWebhookEventProcessor;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Stripe\Charge;
+use Stripe\Event;
+use Stripe\PaymentIntent;
+use Sylius\Component\Payment\Model\GatewayConfigInterface;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class ChargeRefundedWebhookEventProcessorTest extends TestCase
+{
+    /** @var array<string, string[]> */
+    private const SUPPORTED = ['stripe_web_elements' => [Event::CHARGE_REFUNDED]];
+
+    /** @var RetrieveManagerInterface<PaymentIntent>&MockObject */
+    private RetrieveManagerInterface&MockObject $retrieveManager;
+
+    private LoggerInterface&MockObject $logger;
+
+    private ChargeRefundedWebhookEventProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->retrieveManager = $this->createMock(RetrieveManagerInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->processor = new ChargeRefundedWebhookEventProcessor(
+            self::SUPPORTED,
+            $this->retrieveManager,
+            $this->logger,
+        );
+    }
+
+    public function test_it_retrieves_the_payment_intent_and_stores_it_on_the_payment_details(): void
+    {
+        $paymentIntent = PaymentIntent::constructFrom([
+            'id' => 'pi_test_1',
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'latest_charge' => [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+                'refunded' => true,
+            ],
+        ]);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->expects(self::once())->method('setDetails')->with($paymentIntent->toArray());
+        $paymentRequest = $this->createPaymentRequest($payment);
+
+        // Retrieves by the charge's payment_intent id, NOT by the charge id.
+        $this->retrieveManager
+            ->expects(self::once())
+            ->method('retrieve')
+            ->with($paymentRequest, 'pi_test_1')
+            ->willReturn($paymentIntent);
+
+        $this->processor->process($paymentRequest, $this->chargeRefundedEvent(refunded: true));
+    }
+
+    public function test_it_returns_early_when_the_charge_has_no_payment_intent(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->expects(self::never())->method('setDetails');
+        $paymentRequest = $this->createPaymentRequest($payment);
+
+        $this->retrieveManager->expects(self::never())->method('retrieve');
+
+        $event = Event::constructFrom([
+            'id' => 'evt_test_1',
+            'object' => Event::OBJECT_NAME,
+            'type' => Event::CHARGE_REFUNDED,
+            'data' => ['object' => [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+            ]],
+        ]);
+
+        $this->processor->process($paymentRequest, $event);
+    }
+
+    public function test_it_logs_partial_refunds_but_still_stores_details(): void
+    {
+        $paymentIntent = PaymentIntent::constructFrom([
+            'id' => 'pi_test_1',
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'latest_charge' => [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+                'refunded' => false,
+            ],
+        ]);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getId')->willReturn(7);
+        $payment->expects(self::once())->method('setDetails')->with($paymentIntent->toArray());
+        $paymentRequest = $this->createPaymentRequest($payment);
+
+        $this->retrieveManager->method('retrieve')->willReturn($paymentIntent);
+
+        $this->logger->expects(self::once())->method('info');
+
+        $this->processor->process($paymentRequest, $this->chargeRefundedEvent(refunded: false, amountRefunded: 500));
+    }
+
+    public function test_supports_only_the_charge_refunded_event_on_a_supported_factory(): void
+    {
+        $paymentRequest = $this->createPaymentRequest($this->createMock(PaymentInterface::class));
+
+        self::assertTrue($this->processor->supports($paymentRequest, $this->chargeRefundedEvent(refunded: true)));
+
+        $otherEvent = Event::constructFrom([
+            'id' => 'evt_test_2',
+            'object' => Event::OBJECT_NAME,
+            'type' => Event::PAYMENT_INTENT_SUCCEEDED,
+            'data' => ['object' => ['id' => 'pi_test_1', 'object' => PaymentIntent::OBJECT_NAME]],
+        ]);
+        self::assertFalse($this->processor->supports($paymentRequest, $otherEvent));
+    }
+
+    public function test_it_does_not_support_an_unsupported_factory(): void
+    {
+        $paymentRequest = $this->createPaymentRequest(
+            $this->createMock(PaymentInterface::class),
+            factoryName: 'paypal',
+        );
+
+        self::assertFalse($this->processor->supports($paymentRequest, $this->chargeRefundedEvent(refunded: true)));
+    }
+
+    private function chargeRefundedEvent(bool $refunded, int $amountRefunded = 0): Event
+    {
+        return Event::constructFrom([
+            'id' => 'evt_test_1',
+            'object' => Event::OBJECT_NAME,
+            'type' => Event::CHARGE_REFUNDED,
+            'data' => ['object' => [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+                'payment_intent' => 'pi_test_1',
+                'refunded' => $refunded,
+                'amount_refunded' => $amountRefunded,
+            ]],
+        ]);
+    }
+
+    private function createPaymentRequest(
+        PaymentInterface&MockObject $payment,
+        string $factoryName = 'stripe_web_elements',
+    ): PaymentRequestInterface&MockObject {
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $gatewayConfig->method('getFactoryName')->willReturn($factoryName);
+
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $paymentRequest->method('getMethod')->willReturn($paymentMethod);
+
+        return $paymentRequest;
+    }
+}

--- a/tests/Unit/Provider/RefundEventTokenHashResolverTest.php
+++ b/tests/Unit/Provider/RefundEventTokenHashResolverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Provider;
+
+use FluxSE\SyliusStripePlugin\Provider\RefundEventTokenHashResolver;
+use FluxSE\SyliusStripePlugin\Stripe\Factory\ClientFactoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Stripe\Charge;
+use Stripe\PaymentIntent;
+use Stripe\Service\PaymentIntentService;
+use Stripe\StripeClient;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+
+final class RefundEventTokenHashResolverTest extends TestCase
+{
+    private ClientFactoryInterface&MockObject $clientFactory;
+
+    private StripeClient&MockObject $stripeClient;
+
+    private PaymentIntentService&MockObject $paymentIntentService;
+
+    private PaymentMethodInterface&MockObject $paymentMethod;
+
+    private RefundEventTokenHashResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->clientFactory = $this->createMock(ClientFactoryInterface::class);
+        $this->stripeClient = $this->createMock(StripeClient::class);
+        $this->paymentIntentService = $this->createMock(PaymentIntentService::class);
+        $this->paymentMethod = $this->createMock(PaymentMethodInterface::class);
+
+        $this->stripeClient->method('__get')->with('paymentIntents')->willReturn($this->paymentIntentService);
+
+        $this->resolver = new RefundEventTokenHashResolver($this->clientFactory);
+    }
+
+    public function test_it_resolves_token_hash_from_the_related_payment_intent(): void
+    {
+        $charge = Charge::constructFrom([
+            'id' => 'ch_test_1',
+            'object' => Charge::OBJECT_NAME,
+            'payment_intent' => 'pi_test_1',
+        ]);
+
+        $this->clientFactory
+            ->method('createFromPaymentMethod')
+            ->with($this->paymentMethod)
+            ->willReturn($this->stripeClient);
+
+        $this->paymentIntentService
+            ->expects(self::once())
+            ->method('retrieve')
+            ->with('pi_test_1')
+            ->willReturn(PaymentIntent::constructFrom([
+                'id' => 'pi_test_1',
+                'object' => PaymentIntent::OBJECT_NAME,
+                'metadata' => ['token_hash' => 'the-hash'],
+            ]));
+
+        self::assertSame('the-hash', $this->resolver->resolve($charge, $this->paymentMethod));
+    }
+
+    public function test_it_returns_null_when_object_has_no_payment_intent(): void
+    {
+        $charge = Charge::constructFrom([
+            'id' => 'ch_test_1',
+            'object' => Charge::OBJECT_NAME,
+        ]);
+
+        $this->clientFactory->expects(self::never())->method('createFromPaymentMethod');
+
+        self::assertNull($this->resolver->resolve($charge, $this->paymentMethod));
+    }
+
+    public function test_it_returns_null_when_the_payment_intent_has_no_token_hash(): void
+    {
+        $charge = Charge::constructFrom([
+            'id' => 'ch_test_1',
+            'object' => Charge::OBJECT_NAME,
+            'payment_intent' => 'pi_test_1',
+        ]);
+
+        $this->clientFactory
+            ->method('createFromPaymentMethod')
+            ->willReturn($this->stripeClient);
+
+        $this->paymentIntentService
+            ->method('retrieve')
+            ->with('pi_test_1')
+            ->willReturn(PaymentIntent::constructFrom([
+                'id' => 'pi_test_1',
+                'object' => PaymentIntent::OBJECT_NAME,
+                'metadata' => [],
+            ]));
+
+        self::assertNull($this->resolver->resolve($charge, $this->paymentMethod));
+    }
+}

--- a/tests/Unit/Provider/StripeNotifyPaymentProviderTest.php
+++ b/tests/Unit/Provider/StripeNotifyPaymentProviderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Provider;
+
+use FluxSE\SyliusStripePlugin\Provider\RefundEventTokenHashResolverInterface;
+use FluxSE\SyliusStripePlugin\Provider\StripeNotifyPaymentProvider;
+use FluxSE\SyliusStripePlugin\Stripe\Resolver\EventResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Stripe\Charge;
+use Stripe\Event;
+use Stripe\PaymentIntent;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class StripeNotifyPaymentProviderTest extends TestCase
+{
+    private EventResolverInterface&MockObject $eventResolver;
+
+    /** @var PaymentRequestRepositoryInterface<PaymentRequestInterface>&MockObject */
+    private PaymentRequestRepositoryInterface&MockObject $paymentRequestRepository;
+
+    private RefundEventTokenHashResolverInterface&MockObject $refundEventTokenHashResolver;
+
+    private PaymentMethodInterface&MockObject $paymentMethod;
+
+    private StripeNotifyPaymentProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->eventResolver = $this->createMock(EventResolverInterface::class);
+        $this->paymentRequestRepository = $this->createMock(PaymentRequestRepositoryInterface::class);
+        $this->refundEventTokenHashResolver = $this->createMock(RefundEventTokenHashResolverInterface::class);
+        $this->paymentMethod = $this->createMock(PaymentMethodInterface::class);
+
+        $this->provider = new StripeNotifyPaymentProvider(
+            ['stripe_web_elements', 'stripe_checkout'],
+            $this->paymentRequestRepository,
+            $this->eventResolver,
+            $this->refundEventTokenHashResolver,
+        );
+    }
+
+    public function test_it_resolves_the_payment_from_the_object_metadata_token_hash(): void
+    {
+        $event = Event::constructFrom([
+            'id' => 'evt_test_1',
+            'object' => Event::OBJECT_NAME,
+            'type' => Event::PAYMENT_INTENT_SUCCEEDED,
+            'data' => ['object' => [
+                'id' => 'pi_test_1',
+                'object' => PaymentIntent::OBJECT_NAME,
+                'metadata' => ['token_hash' => 'the-hash'],
+            ]],
+        ]);
+        $this->eventResolver->method('resolve')->willReturn($event);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $this->paymentRequestRepository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['hash' => 'the-hash'])
+            ->willReturn($this->paymentRequest($payment));
+
+        // The fallback is not used when the object already carries the token hash.
+        $this->refundEventTokenHashResolver->expects(self::never())->method('resolve');
+
+        self::assertSame($payment, $this->provider->getPayment(new Request(), $this->paymentMethod));
+    }
+
+    public function test_it_falls_back_to_the_refund_resolver_when_the_object_has_no_token_hash(): void
+    {
+        $event = Event::constructFrom([
+            'id' => 'evt_test_1',
+            'object' => Event::OBJECT_NAME,
+            'type' => Event::CHARGE_REFUNDED,
+            'data' => ['object' => [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+                'payment_intent' => 'pi_test_1',
+            ]],
+        ]);
+        $this->eventResolver->method('resolve')->willReturn($event);
+
+        $this->refundEventTokenHashResolver
+            ->expects(self::once())
+            ->method('resolve')
+            ->willReturn('the-hash');
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $this->paymentRequestRepository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['hash' => 'the-hash'])
+            ->willReturn($this->paymentRequest($payment));
+
+        self::assertSame($payment, $this->provider->getPayment(new Request(), $this->paymentMethod));
+    }
+
+    public function test_it_throws_when_no_token_hash_can_be_resolved(): void
+    {
+        $event = Event::constructFrom([
+            'id' => 'evt_test_1',
+            'object' => Event::OBJECT_NAME,
+            'type' => Event::CHARGE_REFUNDED,
+            'data' => ['object' => [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+            ]],
+        ]);
+        $this->eventResolver->method('resolve')->willReturn($event);
+        $this->refundEventTokenHashResolver->method('resolve')->willReturn(null);
+
+        $this->expectException(\LogicException::class);
+
+        $this->provider->getPayment(new Request(), $this->paymentMethod);
+    }
+
+    private function paymentRequest(PaymentInterface $payment): PaymentRequestInterface&MockObject
+    {
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        return $paymentRequest;
+    }
+}


### PR DESCRIPTION
Refunds initiated from the Stripe Dashboard never reached Sylius — the order stayed Paid while the money was returned. The charge.refunded event object is a Charge with no token_hash, so the payment could not be resolved.