### PR TITLE
Add Sylius telemetry support

### DIFF
--- a/LICENSE_OF_TRADEMARK_AND_LOGO
+++ b/LICENSE_OF_TRADEMARK_AND_LOGO
@@ -1,0 +1,162 @@
+Encourage widespread and fair use of Sylius logo and brand identity.
+
+This Trademarks and Logos use policy (the “Policy”) is based on the Ubuntu
+and Symfony trademark policy and published under the CC-BY-SA license. You
+are welcome to base your own project trademark policies off it, just let
+others use your changes and give credit to the Ubuntu and Symfony projects
+as the original source!
+
+Version n°1. Published on April 5th 2019.
+
+The objective of the Policy is to encourage widespread use of the Sylius
+trademarks by the Sylius community while controlling that use in order to
+avoid confusion on the part of Sylius users and the general public, to
+maintain the value of the image and reputation of the trademarks and to
+protect them from inappropriate or unauthorised use.
+
+The sections below describe what is allowed, what isn’t allowed, and cases
+in which you should ask permission.
+If you have any doubt, please contact us and a member of our legal
+representative will be in touch with you shortly.
+If you are aware a breach or misuse of the Sylius trademarks in any
+way, we would appreciate you bringing this to our attention. Please
+contact us so that we can investigate this further.
+
+The Trademarks and Logos
+Sylius sp. z o.o. owns the verbal trademark containing
+in whole or part of the word “Sylius”.
+
+Any verbal mark starting with the letters “Sylius” is sufficiently
+similar to one or more of the trademarks that permission will be
+needed in order to use it.
+
+All verbal trademarks of Sylius sp. z o.o., all distinctive signs used in
+commerce by Sylius sp. z o.o. to designate his products or services related
+to Sylius are collectively referred to as the “Trademarks”.
+
+Permitted use of the Trademarks
+Certain usages of the Trademarks are fine and no specific permission
+from us is needed.
+
+Community advocacy. Sylius is built by its community. We share access to
+the Trademarks with the entire community for the purposes of discussion,
+development and advocacy. We recognise that most of the open source discussion
+and development areas are for non-commercial purposes and will allow the
+use of the Trademarks in this context, provided:
+
+the Trademark is used in a manner consistent with this Policy;
+there is no commercial intent behind the use;
+what you are referring to is in fact Sylius. If someone is confused into
+thinking that what isn’t Sylius is, in fact, Sylius, you are probably doing
+something wrong;
+there is no suggestion (through words or appearance) that your project is
+approved, sponsored, or affiliated with Sylius, Sylius sp. z o.o. or its
+related projects unless it actually has been approved by and is accountable
+to Sylius sp. z o.o. and the Sylius Project.
+Building on Sylius or for Sylius. If you are producing new software which is
+intended for use with or on Sylius, you may use the Trademark in a way which
+indicates the intent of your product. For example, if you are developing a
+system management tool for Sylius, acceptable project titles would be
+“System Management for Sylius” or “Sylius Based Systems Management”. We would
+strongly discourage, and likely would consider to be problematic, a name such
+as SyliusMan, Sylius Management, etc. Furthermore, you may not use the
+Trademarks in a way which implies an endorsement where that doesn’t exist,
+or which attempts to unfairly or confusingly capitalise on the goodwill
+or brand of the project.
+
+Commentary and parody. The Trademarks and Logos are designed to cover use of
+a mark to imply origin or endorsement by the project. When a user downloads
+something called Sylius, they should know it comes from the Sylius project.
+This helps Sylius build a reputation that will not be damaged by confusion
+around what is, and isn’t, Sylius. Using the Trademarks in your discussion,
+commentary, criticism or parody, in ways that unequivocally do not imply
+endorsement, is permissible. Anyone is free to write articles, create
+websites, blog about, or talk about Sylius — as long as it’s clear to
+everyone — including people completely unfamiliar with Sylius — that they
+are simply referring to Sylius and in no way speaking for the Sylius
+project and/or for Sylius sp. z o.o.
+
+We reserve the right to review all usage within the open source community,
+and to object to any usage that appears to overstep the bounds of discussion
+and good-faith non-commercial development. In any event, once a project has
+left the open source project phase or otherwise become a commercial project,
+this Policy does not authorise any use of the Trademarks in connection to
+that project.
+
+Restricted use that requires a trademark licence
+Permission from us is necessary to use any of the Trademarks under any
+circumstances other than those specifically permitted above.
+
+These include but are not limited to:
+
+Any commercial use including for any services related to Sylius such as
+providing training services, conference services, or design services (should
+you wish to provide such services, please contact us beforehand to explore
+Sylius Solution Partner Program);
+Use on or in relation to a software product that includes or is built on top
+of a product supplied by us, if there is any commercial intent associated
+with that product;
+Use in a domain name or URL;
+Use for merchandising purposes, e.g. on t-shirts and the like.
+If you wish to have permission for any of the uses above or for any other use
+which is not specifically referred to in this Policy, please contact us and
+we’ll let you know as soon as possible if your proposed use is permissible.
+Permission may only be granted subject to certain conditions and these may
+include the requirement that you enter into an agreement with us to maintain
+the quality of the product and/or service which you intend to supply at a
+prescribed level.
+
+While there may be exceptions, it is very unlikely that we will approve
+Trademark use in the following cases:
+
+Use of a Trademark in a company name;
+Use of a Trademark in a domain name which has a commercial intent. The
+commercial intent can range from promotion of a company or product, to
+collecting revenue generated by advertising;
+The calling of any software or product by the name Sylius (or another
+related Trademark);
+Use in combination with any other marks or logos. This include use of
+a Trademark in a manner that creates a “combined mark,” or use that
+integrates other wording with the Trademark in a way that the public may
+think of the use as a new mark (for example Club Sylius or SyliusBooks, or
+in a way that by use of special fonts or presentation with nearby words or
+images conveys an impression that the two are tied in some way);
+Use in combination with any product or service which is presented as being
+Certified or Official or formally associated with us or our products or
+services;
+Use in a way which implies an endorsement where that doesn’t exist, or which
+attempts to unfairly or confusingly capitalise on the goodwill or brand of
+the project;
+Use of a Trademark in a manner that disparages Sylius, or Sylius sp. z o.o.;
+or its products and is not clearly third-party parody;
+Use of a Trademark on or in relation to a software product which constitutes
+a substantially modified version of a product supplied by the Sylius project,
+that is to say with material changes to the code, or services relating to
+such a product; and
+Use of a Trademark in a title or metatag of a web page whose sole intention or
+result is to influence search engine rankings or result listings (for example
+use as keyword for advertising purposes), rather than for discussion,
+development or advocacy of the Trademarks.
+Logo usage guidelines
+Except otherwise agreed, any use of Logos shall be expressly authorized by
+writing by Sylius sp. z o.o.. To get any authorization to use any Logo,
+please contact us and a member of our team will be in touch with you shortly.
+
+Our logos are presented in multiple colours and it is important that their
+visual integrity be maintained.
+
+Therefore, when use of Logos is authorized, it is therefore preferable that
+the logos only be used in their standard form but if you should feel the need
+to alter them in any way you should keep the following guidelines in mind.
+
+It should also be borne in mind that the more you wish to vary our logos
+from their standard form the smaller is the chance that we will be able to
+approve your proposed use.
+
+If presented in multiple colours, the logo should only use the “official”
+logo colours.
+You may use transparency and gradient/depth tools but should retain the
+“official” colours.
+Any scaling must retain the original proportions of the logo.
+In case of non-compliance with Trademarks and Logos’ Use Policy or
+applicable law, any use of the Trademarks and/or Logos will be prohibited.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ Kudos to [Prometee](https://github.com/Prometee) and [all contributors](../../co
 
 This plugin is released under the [MIT License](LICENSE).
 
+## Telemetry
+
+This plugin enforces telemetry data collection when used with Sylius.
+Details are described in [TELEMETRY_POLICY.md](./TELEMETRY_POLICY.md).
+
 [ico-version]: https://img.shields.io/packagist/v/flux-se/sylius-stripe-plugin.svg?style=flat-square
 [ico-total-downloads]: https://img.shields.io/packagist/dt/flux-se/sylius-stripe-plugin.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square

--- a/TELEMETRY_POLICY.md
+++ b/TELEMETRY_POLICY.md
@@ -1,0 +1,69 @@
+# Telemetry Policy
+
+## Applicability
+
+This Telemetry Policy applies to the use of this plugin in combination with Sylius.
+
+By installing or using this plugin with Sylius, the user acknowledges that telemetry data is collected and transmitted as described in this document.
+
+---
+
+## Mandatory telemetry
+
+Telemetry data collection is mandatory when this plugin is used.
+
+While this plugin is installed and active, Sylius telemetry operates under the conditions defined by this plugin and cannot be disabled independently.
+Telemetry behavior outside of this scope follows the standard Sylius configuration.
+
+---
+
+## Scope of collected data
+
+Telemetry is limited to non-identifying technical data, which may include:
+
+- Sylius version
+- plugin version
+- PHP version and selected dependency versions
+- identifiers of installed and enabled plugins
+- runtime environment classification (production or non-production)
+
+Telemetry does not include, and is not intended to include:
+
+- personal data
+- customer data
+- order data
+- product data
+- business, transactional, or confidential information
+- authentication credentials or secrets
+
+A detailed description of the Sylius telemetry mechanism is available in the public issue:
+https://github.com/Sylius/Sylius/issues/18588
+
+---
+
+## Purpose and use of telemetry data
+
+Telemetry data is collected for the purpose of:
+
+- understanding usage patterns within the Sylius ecosystem
+- analyzing the adoption and frequency of plugin usage
+- identifying commonly used versions of Sylius and plugins
+- supporting maintenance, compatibility, and future development efforts
+
+Telemetry data is processed in aggregated form and is not used to identify individual users, installations, or businesses.
+
+---
+
+## Licensing
+
+This plugin is distributed under the MIT license.
+
+Telemetry collection constitutes part of the technical operation of the software and does not alter, restrict, or supplement the rights granted under the license.
+
+---
+
+## Changes to this policy
+
+This Telemetry Policy may be updated to reflect changes in telemetry implementation, legal requirements, or operational practices.
+
+Updated versions of this policy will be made available in the plugin repository.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "sylius/core-bundle": "^2.0",
+        "sylius/telemetry": "^1.0",
         "stripe/stripe-php": "^16.1"
     },
     "require-dev": {

--- a/src/FluxSESyliusStripePlugin.php
+++ b/src/FluxSESyliusStripePlugin.php
@@ -6,6 +6,7 @@ namespace FluxSE\SyliusStripePlugin;
 
 use FluxSE\SyliusStripePlugin\DependencyInjection\CompilerPass\LiveTwigComponentCompilerPass;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
+use Sylius\Telemetry\TelemetryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -17,6 +18,7 @@ final class FluxSESyliusStripePlugin extends Bundle
     {
         // Before SyliusUiBundle compiler pass
         $container->addCompilerPass(new LiveTwigComponentCompilerPass(), priority: 501);
+        $container->addCompilerPass(new TelemetryCompilerPass());
     }
 
     public function getPath(): string


### PR DESCRIPTION
Adds telemetry policy and `sylius/telemetry-bundle` as a hard dependency.

- `TELEMETRY_POLICY.md` — describes scope, purpose, and conditions of telemetry data collection
- `composer.json` — requires `sylius/telemetry-bundle: ^1.0`
- `README.md` — telemetry notice pointing to the policy file

Related: https://github.com/Sylius/Sylius/issues/18588