### PR TITLE
[1.1] [Fix]Handle missing webhook transitions for Checkout Session and Payment Intent

### DIFF
--- a/src/DependencyInjection/FluxSESyliusStripeExtension.php
+++ b/src/DependencyInjection/FluxSESyliusStripeExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FluxSE\SyliusStripePlugin\DependencyInjection;
 
+use FluxSE\SyliusStripePlugin\Repository\StripePaymentRequestRepository;
 use Sylius\Bundle\CoreBundle\DependencyInjection\PrependDoctrineMigrationsTrait;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\Config\FileLocator;
@@ -48,6 +49,16 @@ final class FluxSESyliusStripeExtension extends AbstractResourceExtension implem
     public function prepend(ContainerBuilder $container): void
     {
         $this->prependDoctrineMigrations($container);
+
+        $container->prependExtensionConfig('sylius_payment', [
+            'resources' => [
+                'payment_request' => [
+                    'classes' => [
+                        'repository' => StripePaymentRequestRepository::class,
+                    ],
+                ],
+            ],
+        ]);
     }
 
     protected function getMigrationsNamespace(): string

--- a/src/Provider/StripeNotifyPaymentProvider.php
+++ b/src/Provider/StripeNotifyPaymentProvider.php
@@ -5,24 +5,22 @@ declare(strict_types=1);
 namespace FluxSE\SyliusStripePlugin\Provider;
 
 use ArrayAccess;
+use FluxSE\SyliusStripePlugin\Repository\StripePaymentRequestRepositoryInterface;
 use FluxSE\SyliusStripePlugin\Stripe\Resolver\EventResolverInterface;
 use Stripe\StripeObject;
 use Sylius\Bundle\PaymentBundle\Provider\NotifyPaymentProviderInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
-use Sylius\Component\Payment\Model\PaymentRequestInterface;
-use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 final readonly class StripeNotifyPaymentProvider implements NotifyPaymentProviderInterface
 {
     /**
      * @param string[] $supportedFactories
-     * @param PaymentRequestRepositoryInterface<PaymentRequestInterface> $paymentRequestRepository
      */
     public function __construct(
         private array $supportedFactories,
-        private PaymentRequestRepositoryInterface $paymentRequestRepository,
+        private StripePaymentRequestRepositoryInterface $paymentRequestRepository,
         private EventResolverInterface $eventResolver,
     ) {
     }
@@ -50,21 +48,32 @@ final readonly class StripeNotifyPaymentProvider implements NotifyPaymentProvide
         }
 
         $hash = $metadata->offsetGet(MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME);
-        if (!is_string($hash)) {
+        if (is_string($hash)) {
+            $paymentRequest = $this->paymentRequestRepository->findOneBy(['hash' => $hash]);
+            if (null === $paymentRequest) {
+                throw new \LogicException(sprintf(
+                    'Unable to retrieve the payment request (hash:%s) related to this Stripe event (ID:"%s").',
+                    $hash,
+                    $event->id,
+                ));
+            }
+
+            return $paymentRequest->getPayment();
+        }
+
+        $stripeObjectId = $object->offsetGet('id');
+        if (!is_string($stripeObjectId)) {
             throw new \LogicException(sprintf(
                 'The Stripe event object metadata (key: "%s") must be a string.',
                 MetadataProviderInterface::DEFAULT_TOKEN_HASH_KEY_NAME,
             ));
         }
 
-        $paymentRequest = $this->paymentRequestRepository->findOneBy([
-            'hash' => $hash,
-        ]);
+        $paymentRequest = $this->paymentRequestRepository->findOneByStripeObjectId($stripeObjectId);
         if (null === $paymentRequest) {
             throw new \LogicException(sprintf(
-                'Unable to retrieve the payment request (hash:%s) related to this Stripe event (ID:"%s").',
-                $hash,
-                $event->id,
+                'Unable to retrieve the payment request for Stripe event object (ID:"%s").',
+                $stripeObjectId,
             ));
         }
 

--- a/src/Provider/Transition/Checkout/SessionTransitionProvider.php
+++ b/src/Provider/Transition/Checkout/SessionTransitionProvider.php
@@ -51,6 +51,10 @@ final class SessionTransitionProvider implements SessionTransitionProviderInterf
 
     public function isCancel(Session $session): bool
     {
+        if (Session::STATUS_COMPLETE === $session->status) {
+            return $this->sessionModeTransitionProvider->isCancel($session);
+        }
+
         if (!$this->isProcess($session)) {
             return false;
         }

--- a/src/Provider/Transition/WebElements/PaymentIntentTransitionProvider.php
+++ b/src/Provider/Transition/WebElements/PaymentIntentTransitionProvider.php
@@ -17,11 +17,11 @@ final class PaymentIntentTransitionProvider implements PaymentIntentTransitionPr
 
     public function isComplete(PaymentIntent $paymentIntent): bool
     {
-        if ($this->isChargeRefunded($paymentIntent)) {
+        if (PaymentIntent::STATUS_SUCCEEDED !== $paymentIntent->status) {
             return false;
         }
 
-        return PaymentIntent::STATUS_SUCCEEDED === $paymentIntent->status;
+        return !$this->isChargeRefunded($paymentIntent);
     }
 
     public function isFail(PaymentIntent $paymentIntent): bool

--- a/src/Repository/StripePaymentRequestRepository.php
+++ b/src/Repository/StripePaymentRequestRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Repository;
+
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Sylius\Bundle\PaymentBundle\Doctrine\ORM\PaymentRequestRepository;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+class StripePaymentRequestRepository extends PaymentRequestRepository implements StripePaymentRequestRepositoryInterface
+{
+    public function findOneByStripeObjectId(string $stripeObjectId): ?PaymentRequestInterface
+    {
+        $em = $this->getEntityManager();
+        $prMeta = $em->getClassMetadata($this->getEntityName());
+        $pMeta = $em->getClassMetadata($prMeta->getAssociationTargetClass('payment'));
+
+        $rsm = new ResultSetMappingBuilder($em);
+        $rsm->addRootEntityFromClassMetadata($this->getEntityName(), 'pr');
+
+        /** @var PaymentRequestInterface|null $result */
+        $result = $em->createNativeQuery(
+            sprintf(
+                'SELECT pr.* FROM %s pr
+                 INNER JOIN %s p ON pr.payment_id = p.id
+                 WHERE JSON_VALUE(p.details, \'$.id\') = :id
+                    OR JSON_VALUE(p.details, \'$.payment_intent\') = :id
+                    OR JSON_VALUE(p.details, \'$.payment_intent.id\') = :id
+                 LIMIT 1',
+                $prMeta->getTableName(),
+                $pMeta->getTableName(),
+            ),
+            $rsm,
+        )
+            ->setParameter('id', $stripeObjectId)
+            ->getOneOrNullResult();
+
+        return $result;
+    }
+}

--- a/src/Repository/StripePaymentRequestRepositoryInterface.php
+++ b/src/Repository/StripePaymentRequestRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Repository;
+
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+interface StripePaymentRequestRepositoryInterface
+{
+    public function findOneByStripeObjectId(string $stripeObjectId): ?PaymentRequestInterface;
+}

--- a/tests/Unit/Provider/Transition/Checkout/SessionTransitionProviderTest.php
+++ b/tests/Unit/Provider/Transition/Checkout/SessionTransitionProviderTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\Provider\Transition\Checkout;
+
+use FluxSE\SyliusStripePlugin\Provider\Transition\Checkout\PaymentModeTransitionProvider;
+use FluxSE\SyliusStripePlugin\Provider\Transition\Checkout\SessionTransitionProvider;
+use FluxSE\SyliusStripePlugin\Provider\Transition\WebElements\PaymentIntentTransitionProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Stripe\Charge;
+use Stripe\Checkout\Session;
+use Stripe\PaymentIntent;
+
+final class SessionTransitionProviderTest extends TestCase
+{
+    private SessionTransitionProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new SessionTransitionProvider(
+            new PaymentModeTransitionProvider(new PaymentIntentTransitionProvider()),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, array<string, mixed>|null, bool}>
+     */
+    public static function cancelDataProvider(): iterable
+    {
+        yield 'complete session, PI canceled → cancel' => [
+            Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_CANCELED, null, true,
+        ];
+
+        yield 'complete session, PI requires_payment_method with last_payment_error → cancel' => [
+            Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_REQUIRES_PAYMENT_METHOD, ['code' => 'payment_method_provider_decline'], true,
+        ];
+
+        yield 'complete session, PI succeeded → no cancel' => [
+            Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_PAID, PaymentIntent::STATUS_SUCCEEDED, null, false,
+        ];
+
+        yield 'complete session, PI requires_capture → no cancel' => [
+            Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_REQUIRES_CAPTURE, null, false,
+        ];
+
+        yield 'complete session, PI processing → no cancel' => [
+            Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_PROCESSING, null, false,
+        ];
+
+        yield 'complete session, PI requires_payment_method without error → no cancel' => [
+            Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_REQUIRES_PAYMENT_METHOD, null, false,
+        ];
+
+        yield 'expired session → no cancel' => [
+            Session::STATUS_EXPIRED, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_CANCELED, null, false,
+        ];
+
+        yield 'open session → no cancel' => [
+            Session::STATUS_OPEN, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_CANCELED, null, false,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|null $lastPaymentError
+     */
+    #[DataProvider('cancelDataProvider')]
+    public function test_is_cancel(
+        string $sessionStatus,
+        string $sessionPaymentStatus,
+        string $paymentIntentStatus,
+        ?array $lastPaymentError,
+        bool $expected,
+    ): void {
+        $session = $this->createSession($sessionStatus, $sessionPaymentStatus, $paymentIntentStatus, $lastPaymentError);
+
+        self::assertSame($expected, $this->provider->isCancel($session));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function authorizeDataProvider(): iterable
+    {
+        yield 'complete, requires_capture → authorize' => [Session::STATUS_COMPLETE, PaymentIntent::STATUS_REQUIRES_CAPTURE, true];
+        yield 'complete, succeeded → no authorize' => [Session::STATUS_COMPLETE, PaymentIntent::STATUS_SUCCEEDED, false];
+        yield 'complete, canceled → no authorize' => [Session::STATUS_COMPLETE, PaymentIntent::STATUS_CANCELED, false];
+        yield 'expired → no authorize' => [Session::STATUS_EXPIRED, PaymentIntent::STATUS_REQUIRES_CAPTURE, false];
+        yield 'open → no authorize' => [Session::STATUS_OPEN, PaymentIntent::STATUS_REQUIRES_CAPTURE, false];
+    }
+
+    #[DataProvider('authorizeDataProvider')]
+    public function test_is_authorize(string $sessionStatus, string $paymentIntentStatus, bool $expected): void
+    {
+        $session = $this->createSession($sessionStatus, Session::PAYMENT_STATUS_UNPAID, $paymentIntentStatus);
+
+        self::assertSame($expected, $this->provider->isAuthorize($session));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, bool}>
+     */
+    public static function completeDataProvider(): iterable
+    {
+        yield 'complete, succeeded, paid → complete' => [Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_PAID, PaymentIntent::STATUS_SUCCEEDED, true];
+        yield 'complete, succeeded, unpaid → no complete' => [Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_SUCCEEDED, false];
+        yield 'complete, requires_capture, paid → no complete' => [Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_PAID, PaymentIntent::STATUS_REQUIRES_CAPTURE, false];
+        yield 'expired → no complete' => [Session::STATUS_EXPIRED, Session::PAYMENT_STATUS_PAID, PaymentIntent::STATUS_SUCCEEDED, false];
+    }
+
+    #[DataProvider('completeDataProvider')]
+    public function test_is_complete(
+        string $sessionStatus,
+        string $sessionPaymentStatus,
+        string $paymentIntentStatus,
+        bool $expected,
+    ): void {
+        $session = $this->createSession($sessionStatus, $sessionPaymentStatus, $paymentIntentStatus);
+
+        self::assertSame($expected, $this->provider->isComplete($session));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function failDataProvider(): iterable
+    {
+        yield 'expired → fail' => [Session::STATUS_EXPIRED, true];
+        yield 'complete → no fail' => [Session::STATUS_COMPLETE, false];
+        yield 'open → no fail' => [Session::STATUS_OPEN, false];
+    }
+
+    #[DataProvider('failDataProvider')]
+    public function test_is_fail(string $sessionStatus, bool $expected): void
+    {
+        $session = $this->createSession($sessionStatus, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_CANCELED);
+
+        self::assertSame($expected, $this->provider->isFail($session));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, bool}>
+     */
+    public static function processDataProvider(): iterable
+    {
+        yield 'complete, processing, unpaid → process' => [Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_PROCESSING, true];
+        yield 'complete, processing, paid → no process' => [Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_PAID, PaymentIntent::STATUS_PROCESSING, false];
+        yield 'complete, succeeded, unpaid → no process' => [Session::STATUS_COMPLETE, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_SUCCEEDED, false];
+        yield 'expired → no process' => [Session::STATUS_EXPIRED, Session::PAYMENT_STATUS_UNPAID, PaymentIntent::STATUS_PROCESSING, false];
+    }
+
+    #[DataProvider('processDataProvider')]
+    public function test_is_process(
+        string $sessionStatus,
+        string $sessionPaymentStatus,
+        string $paymentIntentStatus,
+        bool $expected,
+    ): void {
+        $session = $this->createSession($sessionStatus, $sessionPaymentStatus, $paymentIntentStatus);
+
+        self::assertSame($expected, $this->provider->isProcess($session));
+    }
+
+    /**
+     * @param array<string, mixed>|null $lastPaymentError
+     */
+    private function createSession(
+        string $sessionStatus,
+        string $sessionPaymentStatus,
+        string $paymentIntentStatus,
+        ?array $lastPaymentError = null,
+        bool $chargeRefunded = false,
+    ): Session {
+        $paymentIntentData = [
+            'id' => 'pi_test_1',
+            'object' => PaymentIntent::OBJECT_NAME,
+            'status' => $paymentIntentStatus,
+        ];
+
+        $paymentIntentData['last_payment_error'] = $lastPaymentError;
+
+        if ($chargeRefunded || $paymentIntentStatus === PaymentIntent::STATUS_SUCCEEDED) {
+            $paymentIntentData['latest_charge'] = [
+                'id' => 'ch_test_1',
+                'object' => Charge::OBJECT_NAME,
+                'refunded' => $chargeRefunded,
+            ];
+        }
+
+        return Session::constructFrom([
+            'id' => 'cs_test_1',
+            'object' => Session::OBJECT_NAME,
+            'mode' => Session::MODE_PAYMENT,
+            'status' => $sessionStatus,
+            'payment_status' => $sessionPaymentStatus,
+            'payment_intent' => $paymentIntentData,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
  
  - Fixed `PaymentIntentTransitionProvider::isComplete()` throwing \LogicException when latest_charge is not a fully-expanded Charge object on a cancelled PaymentIntent — status is now checked first,
  isChargeRefunded() is called only for status === succeeded
  - Fixed `SessionTransitionProvider::isCancel()` always returning false for authorized payments that were voided — added STATUS_COMPLETE fast-path so cancellation is correctly detected regardless of
  PaymentIntent status
  - As a side-effect, orders with failed async payments (e.g. SEPA) now recover to awaiting_payment instead of being stuck in an inconsistent state
  - Added unit tests for `SessionTransitionProvider` covering all transition scenarios (isCancel, isAuthorize, isComplete, isFail, isProcess)
