### PR TITLE
Handle refund rejected by Stripe for already refunded or charged back charges

### DIFF
--- a/features/admin/stripe_checkout/refunding_order.feature
+++ b/features/admin/stripe_checkout/refunding_order.feature
@@ -25,6 +25,21 @@ Feature: Refunding an order with Stripe Checkout Session
         And it should have payment state "Refunded"
 
     @api @ui
+    Scenario Outline: Gracefully handling a Stripe Checkout Session refund rejected on the Stripe side
+        Given this order is already paid using Stripe Checkout
+        And I am viewing the summary of this order
+        And I am prepared to refund this order, but Stripe will reject the refund because the charge was <reason>
+        When I mark this order's payment as refunded
+        Then I should be notified that the order's payment has been successfully refunded
+        And it should have payment with state refunded
+        And it should have payment state "Refunded"
+
+        Examples:
+            | reason           |
+            | already refunded |
+            | charged back     |
+
+    @api @ui
     Scenario: Initializing the Stripe refund for a Stripe Checkout Session mode subscription
         Given this order related to a subscription is already paid using Stripe Checkout
         And I am viewing the summary of this order

--- a/features/admin/stripe_web_elements/refunding_order.feature
+++ b/features/admin/stripe_web_elements/refunding_order.feature
@@ -23,3 +23,17 @@ Feature: Refunding an order with Stripe JS
         Then I should be notified that the order's payment has been successfully refunded
         And it should have payment with state refunded
         And it should have payment state "Refunded"
+
+    @api @ui
+    Scenario Outline: Gracefully handling a refund rejected on the Stripe side
+        Given I am viewing the summary of this order
+        And I am prepared to refund this order, but Stripe will reject the refund because the charge was <reason>
+        When I mark this order's payment as refunded
+        Then I should be notified that the order's payment has been successfully refunded
+        And it should have payment with state refunded
+        And it should have payment state "Refunded"
+
+        Examples:
+            | reason           |
+            | already refunded |
+            | charged back     |

--- a/src/CommandHandler/Checkout/RefundPaymentRequestHandler.php
+++ b/src/CommandHandler/Checkout/RefundPaymentRequestHandler.php
@@ -10,6 +10,8 @@ use FluxSE\SyliusStripePlugin\Manager\Checkout\RetrieveManagerInterface;
 use FluxSE\SyliusStripePlugin\Manager\Refund\CreateManagerInterface;
 use FluxSE\SyliusStripePlugin\Processor\PaymentTransitionProcessorInterface;
 use FluxSE\SyliusStripePlugin\Provider\Refund\PaymentIntentToRefundProviderInterface;
+use Stripe\ErrorObject;
+use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
@@ -21,6 +23,12 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 final readonly class RefundPaymentRequestHandler
 {
     use FailedAwarePaymentRequestHandlerTrait;
+
+    /** @var list<string> Stripe error codes for which a refund is rejected because it was already settled against the customer */
+    private const IGNORABLE_REFUND_REJECTION_CODES = [
+        ErrorObject::CODE_CHARGE_ALREADY_REFUNDED,
+        ErrorObject::CODE_CHARGE_DISPUTED,
+    ];
 
     public function __construct(
         private PaymentRequestProviderInterface $paymentRequestProvider,
@@ -93,7 +101,21 @@ final readonly class RefundPaymentRequestHandler
             'amount' => $refundPaymentRequest->getAmount(),
         ]);
 
-        $refund = $this->createRefundManager->create($paymentRequest);
+        try {
+            $refund = $this->createRefundManager->create($paymentRequest);
+        } catch (InvalidRequestException $exception) {
+            // Only treat refunds that Stripe rejects because the money has already left the merchant
+            // (the charge was fully refunded or charged back) as a graceful failure. Any other invalid request is
+            // a real problem and must bubble up instead of silently closing the refund on the Sylius side.
+            if (!in_array($exception->getStripeCode(), self::IGNORABLE_REFUND_REJECTION_CODES, true)) {
+                throw $exception;
+            }
+
+            $this->failWithReason($paymentRequest, $exception->getMessage());
+
+            return;
+        }
+
         $session = $this->retrieveCheckoutManager->retrieve($paymentRequest, $id);
 
         $paymentRequest->setResponseData($refund->toArray());

--- a/src/CommandHandler/WebElements/RefundPaymentRequestHandler.php
+++ b/src/CommandHandler/WebElements/RefundPaymentRequestHandler.php
@@ -9,6 +9,8 @@ use FluxSE\SyliusStripePlugin\CommandHandler\FailedAwarePaymentRequestHandlerTra
 use FluxSE\SyliusStripePlugin\Manager\Refund\CreateManagerInterface;
 use FluxSE\SyliusStripePlugin\Manager\WebElements\RetrieveManagerInterface;
 use FluxSE\SyliusStripePlugin\Processor\PaymentTransitionProcessorInterface;
+use Stripe\ErrorObject;
+use Stripe\Exception\InvalidRequestException;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
 use Sylius\Component\Payment\PaymentRequestTransitions;
@@ -18,6 +20,12 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 final readonly class RefundPaymentRequestHandler
 {
     use FailedAwarePaymentRequestHandlerTrait;
+
+    /** @var list<string> Stripe error codes for which a refund is rejected because it was already settled against the customer */
+    private const IGNORABLE_REFUND_REJECTION_CODES = [
+        ErrorObject::CODE_CHARGE_ALREADY_REFUNDED,
+        ErrorObject::CODE_CHARGE_DISPUTED,
+    ];
 
     public function __construct(
         private PaymentRequestProviderInterface $paymentRequestProvider,
@@ -75,7 +83,21 @@ final readonly class RefundPaymentRequestHandler
             'amount' => $refundPaymentRequest->getAmount(),
         ]);
 
-        $refund = $this->createRefundManager->create($paymentRequest);
+        try {
+            $refund = $this->createRefundManager->create($paymentRequest);
+        } catch (InvalidRequestException $exception) {
+            // Only treat refunds that Stripe rejects because the money has already left the merchant
+            // (the charge was fully refunded or charged back) as a graceful failure. Any other invalid request is
+            // a real problem and must bubble up instead of silently closing the refund on the Sylius side.
+            if (!in_array($exception->getStripeCode(), self::IGNORABLE_REFUND_REJECTION_CODES, true)) {
+                throw $exception;
+            }
+
+            $this->failWithReason($paymentRequest, $exception->getMessage());
+
+            return;
+        }
+
         $paymentIntent = $this->retrievePaymentIntentManager->retrieve($paymentRequest, $id);
 
         $paymentRequest->setResponseData($refund->toArray());

--- a/tests/Behat/Context/Setup/ManagingStripeCheckoutOrdersContext.php
+++ b/tests/Behat/Context/Setup/ManagingStripeCheckoutOrdersContext.php
@@ -272,6 +272,24 @@ class ManagingStripeCheckoutOrdersContext implements ManagingStripeOrdersContext
     }
 
     /**
+     * @Given /^I am prepared to refund (this order), but Stripe will reject the refund because the charge was (already refunded|charged back)$/
+     */
+    public function iAmPreparedToRefundThisOrderRejectedByStripe(OrderInterface $order, string $reason): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $order->getLastPayment(BasePaymentInterface::STATE_COMPLETED);
+
+        $amount = $payment->getAmount();
+        if (null === $amount) {
+            return;
+        }
+
+        [$message, $code] = StripeRefundRejection::forReason($reason);
+
+        $this->stripeCheckoutSessionMocker->mockRefundPaymentRejectedByStripe($amount, $message, $code);
+    }
+
+    /**
      * @Given /^I am prepared to refund (this order) related to a subscription$/
      */
     public function iAmPreparedToRefundThisOrderRelatedToASubscription(OrderInterface $order): void

--- a/tests/Behat/Context/Setup/ManagingStripeCheckoutOrdersContext.php
+++ b/tests/Behat/Context/Setup/ManagingStripeCheckoutOrdersContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FluxSE\SyliusStripePlugin\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Stripe\Checkout\Session;
 use Stripe\Invoice;
@@ -271,9 +272,7 @@ class ManagingStripeCheckoutOrdersContext implements ManagingStripeOrdersContext
         $this->stripeCheckoutSessionMocker->mockRefundPayment($amount);
     }
 
-    /**
-     * @Given /^I am prepared to refund (this order), but Stripe will reject the refund because the charge was (already refunded|charged back)$/
-     */
+    #[Given('/^I am prepared to refund (this order), but Stripe will reject the refund because the charge was (already refunded|charged back)$/')]
     public function iAmPreparedToRefundThisOrderRejectedByStripe(OrderInterface $order, string $reason): void
     {
         /** @var PaymentInterface $payment */

--- a/tests/Behat/Context/Setup/ManagingStripeOrdersContextInterface.php
+++ b/tests/Behat/Context/Setup/ManagingStripeOrdersContextInterface.php
@@ -24,4 +24,6 @@ interface ManagingStripeOrdersContextInterface extends Context
     public function iAmPreparedToCancelAuthorizationOnThisOrder(OrderInterface $order): void;
 
     public function iAmPreparedToRefundThisOrder(OrderInterface $order): void;
+
+    public function iAmPreparedToRefundThisOrderRejectedByStripe(OrderInterface $order, string $reason): void;
 }

--- a/tests/Behat/Context/Setup/ManagingStripeWebElementsOrdersContext.php
+++ b/tests/Behat/Context/Setup/ManagingStripeWebElementsOrdersContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FluxSE\SyliusStripePlugin\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Stripe\PaymentIntent;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
@@ -185,9 +186,7 @@ class ManagingStripeWebElementsOrdersContext implements ManagingStripeOrdersCont
         $this->stripeWebElementsMocker->mockRefundPayment($amount);
     }
 
-    /**
-     * @Given /^I am prepared to refund (this order), but Stripe will reject the refund because the charge was (already refunded|charged back)$/
-     */
+    #[Given('/^I am prepared to refund (this order), but Stripe will reject the refund because the charge was (already refunded|charged back)$/')]
     public function iAmPreparedToRefundThisOrderRejectedByStripe(OrderInterface $order, string $reason): void
     {
         /** @var PaymentInterface $payment */

--- a/tests/Behat/Context/Setup/ManagingStripeWebElementsOrdersContext.php
+++ b/tests/Behat/Context/Setup/ManagingStripeWebElementsOrdersContext.php
@@ -184,4 +184,22 @@ class ManagingStripeWebElementsOrdersContext implements ManagingStripeOrdersCont
 
         $this->stripeWebElementsMocker->mockRefundPayment($amount);
     }
+
+    /**
+     * @Given /^I am prepared to refund (this order), but Stripe will reject the refund because the charge was (already refunded|charged back)$/
+     */
+    public function iAmPreparedToRefundThisOrderRejectedByStripe(OrderInterface $order, string $reason): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $order->getLastPayment(BasePaymentInterface::STATE_COMPLETED);
+
+        $amount = $payment->getAmount();
+        if (null === $amount) {
+            return;
+        }
+
+        [$message, $code] = StripeRefundRejection::forReason($reason);
+
+        $this->stripeWebElementsMocker->mockRefundPaymentRejectedByStripe($amount, $message, $code);
+    }
 }

--- a/tests/Behat/Context/Setup/StripeRefundRejection.php
+++ b/tests/Behat/Context/Setup/StripeRefundRejection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Behat\Context\Setup;
+
+/**
+ * Maps a human-readable rejection reason (used in Behat steps) to the matching
+ * Stripe error message and code returned by the mocked Refund create endpoint.
+ */
+final class StripeRefundRejection
+{
+    /**
+     * @return array{0: string, 1: string} message and Stripe error code
+     */
+    public static function forReason(string $reason): array
+    {
+        return match ($reason) {
+            'already refunded' => [
+                'Charge ch_test_1 has already been refunded.',
+                'charge_already_refunded',
+            ],
+            'charged back' => [
+                'Charge ch_test_1 has been charged back; cannot issue a refund.',
+                'charge_disputed',
+            ],
+            default => throw new \InvalidArgumentException(sprintf('Unknown Stripe refund rejection reason "%s".', $reason)),
+        };
+    }
+}

--- a/tests/Behat/Context/Setup/StripeRefundRejection.php
+++ b/tests/Behat/Context/Setup/StripeRefundRejection.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\FluxSE\SyliusStripePlugin\Behat\Context\Setup;
 
-/**
- * Maps a human-readable rejection reason (used in Behat steps) to the matching
- * Stripe error message and code returned by the mocked Refund create endpoint.
- */
 final class StripeRefundRejection
 {
-    /**
-     * @return array{0: string, 1: string} message and Stripe error code
-     */
+    /** @return array{0: string, 1: string} message and Stripe error code */
     public static function forReason(string $reason): array
     {
         return match ($reason) {

--- a/tests/Behat/Mocker/Api/RefundMocker.php
+++ b/tests/Behat/Mocker/Api/RefundMocker.php
@@ -31,6 +31,23 @@ class RefundMocker
         );
     }
 
+    public function mockCreateActionWithError(string $message, string $code): void
+    {
+        $this->stripeClientWithExpectations->addExpectation(
+            'post',
+            $this->getRefundBaseUrl(),
+            [
+                'error' => [
+                    'type' => 'invalid_request_error',
+                    'code' => $code,
+                    'message' => $message,
+                ],
+            ],
+            false,
+            400,
+        );
+    }
+
     private function getRefundBaseUrl(): string
     {
         return Stripe::$apiBase . Refund::classUrl();

--- a/tests/Behat/Mocker/StripeCheckoutMocker.php
+++ b/tests/Behat/Mocker/StripeCheckoutMocker.php
@@ -82,6 +82,24 @@ class StripeCheckoutMocker
         ]);
     }
 
+    public function mockRefundPaymentRejectedByStripe(int $amount, string $message, string $code): void
+    {
+        $this->checkoutSessionMocker->mockRetrieveAction([
+            'mode' => Session::MODE_PAYMENT,
+            'status' => Session::STATUS_COMPLETE,
+            'payment_status' => Session::PAYMENT_STATUS_PAID,
+            'amount_total' => $amount,
+            PaymentIntent::OBJECT_NAME => [
+                'id' => 'pi_test_1',
+                'object' => PaymentIntent::OBJECT_NAME,
+                'status' => PaymentIntent::STATUS_SUCCEEDED,
+                'capture_method' => PaymentIntent::CAPTURE_METHOD_AUTOMATIC,
+            ],
+        ]);
+
+        $this->refundMocker->mockCreateActionWithError($message, $code);
+    }
+
     public function mockRefundSubscription(int $amount): void
     {
         $subscriptionData = [

--- a/tests/Behat/Mocker/StripeClientWithExpectations.php
+++ b/tests/Behat/Mocker/StripeClientWithExpectations.php
@@ -18,8 +18,13 @@ final class StripeClientWithExpectations implements StripeClientWithExpectations
     ) {
     }
 
-    public function addExpectation(string $method, string $absUrl, array $body, bool $mergeParams = false): void
-    {
+    public function addExpectation(
+        string $method,
+        string $absUrl,
+        array $body,
+        bool $mergeParams = false,
+        int $statusCode = 200,
+    ): void {
         $cacheItem = $this->getCacheItem();
         $expectations = $this->getExpectations();
         $expectations[] = [
@@ -27,6 +32,7 @@ final class StripeClientWithExpectations implements StripeClientWithExpectations
             'absUrl' => $absUrl,
             'body' => $body,
             'mergeParams' => $mergeParams,
+            'statusCode' => $statusCode,
         ];
         $cacheItem->set($expectations);
         $this->cache->save($cacheItem);
@@ -49,6 +55,7 @@ final class StripeClientWithExpectations implements StripeClientWithExpectations
          *  absUrl: string,
          *  body: array<string, string|array<string, string>>,
          *  mergeParams: bool,
+         *  statusCode: int,
          * }> $expectations */
         $expectations = $this->getCacheItem()->get();
 
@@ -97,7 +104,7 @@ final class StripeClientWithExpectations implements StripeClientWithExpectations
 
         return [
             json_encode($body, \JSON_THROW_ON_ERROR),
-            200,
+            $expectation['statusCode'],
             [],
         ];
     }

--- a/tests/Behat/Mocker/StripeClientWithExpectationsInterface.php
+++ b/tests/Behat/Mocker/StripeClientWithExpectationsInterface.php
@@ -15,9 +15,15 @@ interface StripeClientWithExpectationsInterface extends ClientInterface
     public const CACHE_KEY = 'stripe_client_expectations';
 
     /**
-     * @param array<key-of<T>, mixed> $body
+     * @param array<key-of<T>, mixed>|array{error: array<string, mixed>} $body
      */
-    public function addExpectation(string $method, string $absUrl, array $body, bool $mergeParams = false): void;
+    public function addExpectation(
+        string $method,
+        string $absUrl,
+        array $body,
+        bool $mergeParams = false,
+        int $statusCode = 200,
+    ): void;
 
     public function hasExpectations(): bool;
 
@@ -27,6 +33,7 @@ interface StripeClientWithExpectationsInterface extends ClientInterface
      *      absUrl: string,
      *      body: array<string, string|array<string, string>>,
      *      mergeParams: bool,
+     *      statusCode: int,
      *  }>
      */
     public function getExpectations(): array;

--- a/tests/Behat/Mocker/StripeWebElementsMocker.php
+++ b/tests/Behat/Mocker/StripeWebElementsMocker.php
@@ -59,6 +59,17 @@ final class StripeWebElementsMocker
         ]);
     }
 
+    public function mockRefundPaymentRejectedByStripe(int $amount, string $message, string $code): void
+    {
+        $this->paymentIntentMocker->mockRetrieveAction([
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'capture_method' => PaymentIntent::CAPTURE_METHOD_AUTOMATIC,
+            'amount' => $amount,
+        ]);
+
+        $this->refundMocker->mockCreateActionWithError($message, $code);
+    }
+
     public function mockCompleteAuthorized(string $status, string $captureMethod): void
     {
         $this->paymentIntentMocker->mockRetrieveAction([

--- a/tests/Unit/CommandHandler/Checkout/RefundPaymentRequestHandlerTest.php
+++ b/tests/Unit/CommandHandler/Checkout/RefundPaymentRequestHandlerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\CommandHandler\Checkout;
+
+use FluxSE\SyliusStripePlugin\Command\Checkout\RefundPaymentRequest;
+use FluxSE\SyliusStripePlugin\CommandHandler\Checkout\RefundPaymentRequestHandler;
+use FluxSE\SyliusStripePlugin\Manager\Checkout\RetrieveManagerInterface;
+use FluxSE\SyliusStripePlugin\Manager\Refund\CreateManagerInterface;
+use FluxSE\SyliusStripePlugin\Processor\PaymentTransitionProcessorInterface;
+use FluxSE\SyliusStripePlugin\Provider\Refund\PaymentIntentToRefundProviderInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Stripe\Checkout\Session;
+use Stripe\ErrorObject;
+use Stripe\Exception\InvalidRequestException;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+
+#[AllowMockObjectsWithoutExpectations]
+final class RefundPaymentRequestHandlerTest extends TestCase
+{
+    /** @var PaymentRequestProviderInterface&MockObject */
+    private PaymentRequestProviderInterface $paymentRequestProvider;
+
+    /** @var RetrieveManagerInterface&MockObject */
+    private RetrieveManagerInterface $retrieveCheckoutManager;
+
+    /** @var PaymentIntentToRefundProviderInterface&MockObject */
+    private PaymentIntentToRefundProviderInterface $refundPaymentProvider;
+
+    /** @var PaymentIntentToRefundProviderInterface&MockObject */
+    private PaymentIntentToRefundProviderInterface $refundSubscriptionInitProvider;
+
+    /** @var CreateManagerInterface&MockObject */
+    private CreateManagerInterface $createRefundManager;
+
+    /** @var PaymentTransitionProcessorInterface&MockObject */
+    private PaymentTransitionProcessorInterface $paymentTransitionProcessor;
+
+    /** @var StateMachineInterface&MockObject */
+    private StateMachineInterface $stateMachine;
+
+    private RefundPaymentRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->paymentRequestProvider = $this->createMock(PaymentRequestProviderInterface::class);
+        $this->retrieveCheckoutManager = $this->createMock(RetrieveManagerInterface::class);
+        $this->refundPaymentProvider = $this->createMock(PaymentIntentToRefundProviderInterface::class);
+        $this->refundSubscriptionInitProvider = $this->createMock(PaymentIntentToRefundProviderInterface::class);
+        $this->createRefundManager = $this->createMock(CreateManagerInterface::class);
+        $this->paymentTransitionProcessor = $this->createMock(PaymentTransitionProcessorInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+
+        $this->handler = new RefundPaymentRequestHandler(
+            $this->paymentRequestProvider,
+            $this->retrieveCheckoutManager,
+            $this->refundPaymentProvider,
+            $this->refundSubscriptionInitProvider,
+            $this->createRefundManager,
+            $this->paymentTransitionProcessor,
+            $this->stateMachine,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function benignRefundRejections(): iterable
+    {
+        yield 'already refunded' => [
+            'Charge ch_123 has already been refunded.',
+            ErrorObject::CODE_CHARGE_ALREADY_REFUNDED,
+        ];
+        yield 'charged back' => [
+            'Charge ch_123 has been charged back; cannot issue a refund.',
+            ErrorObject::CODE_CHARGE_DISPUTED,
+        ];
+    }
+
+    #[DataProvider('benignRefundRejections')]
+    public function test_it_fails_the_payment_request_when_stripe_rejects_an_already_settled_refund(
+        string $message,
+        string $code,
+    ): void {
+        $command = new RefundPaymentRequest('hash', 1000);
+
+        $paymentRequest = $this->createPaymentRequestExpectingRetrievableSession($command);
+
+        $exception = new InvalidRequestException($message);
+        $exception->setStripeCode($code);
+        $this->createRefundManager->method('create')->willThrowException($exception);
+
+        $paymentRequest->expects(self::once())
+            ->method('setResponseData')
+            ->with(['reason' => $message]);
+
+        $this->stateMachine->expects(self::once())
+            ->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->paymentTransitionProcessor->expects(self::never())->method('process');
+
+        $this->handler->__invoke($command);
+    }
+
+    public function test_it_rethrows_unexpected_stripe_invalid_request_errors(): void
+    {
+        $command = new RefundPaymentRequest('hash', 1000);
+
+        $paymentRequest = $this->createPaymentRequestExpectingRetrievableSession($command);
+
+        $exception = new InvalidRequestException('Refund amount is greater than charge amount.');
+        $exception->setStripeCode(ErrorObject::CODE_AMOUNT_TOO_LARGE);
+        $this->createRefundManager->method('create')->willThrowException($exception);
+
+        $paymentRequest->expects(self::never())->method('setResponseData');
+        $this->stateMachine->expects(self::never())->method('apply');
+        $this->paymentTransitionProcessor->expects(self::never())->method('process');
+
+        $this->expectExceptionObject($exception);
+
+        $this->handler->__invoke($command);
+    }
+
+    /**
+     * @return PaymentRequestInterface&MockObject
+     */
+    private function createPaymentRequestExpectingRetrievableSession(
+        RefundPaymentRequest $command,
+    ): PaymentRequestInterface {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getDetails')->willReturn(['id' => 'cs_123']);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->paymentRequestProvider->method('provide')->with($command)->willReturn($paymentRequest);
+
+        $session = Session::constructFrom([
+            'id' => 'cs_123',
+            'payment_status' => Session::PAYMENT_STATUS_PAID,
+            'amount_total' => 1000,
+        ]);
+        $this->retrieveCheckoutManager->method('retrieve')->willReturn($session);
+
+        $this->refundPaymentProvider->method('provide')->with($paymentRequest)->willReturn('pi_123');
+
+        return $paymentRequest;
+    }
+}

--- a/tests/Unit/CommandHandler/WebElements/RefundPaymentRequestHandlerTest.php
+++ b/tests/Unit/CommandHandler/WebElements/RefundPaymentRequestHandlerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\CommandHandler\WebElements;
+
+use FluxSE\SyliusStripePlugin\Command\WebElements\RefundPaymentRequest;
+use FluxSE\SyliusStripePlugin\CommandHandler\WebElements\RefundPaymentRequestHandler;
+use FluxSE\SyliusStripePlugin\Manager\Refund\CreateManagerInterface;
+use FluxSE\SyliusStripePlugin\Manager\WebElements\RetrieveManagerInterface;
+use FluxSE\SyliusStripePlugin\Processor\PaymentTransitionProcessorInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Stripe\ErrorObject;
+use Stripe\Exception\InvalidRequestException;
+use Stripe\PaymentIntent;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+
+#[AllowMockObjectsWithoutExpectations]
+final class RefundPaymentRequestHandlerTest extends TestCase
+{
+    /** @var PaymentRequestProviderInterface&MockObject */
+    private PaymentRequestProviderInterface $paymentRequestProvider;
+
+    /** @var RetrieveManagerInterface&MockObject */
+    private RetrieveManagerInterface $retrievePaymentIntentManager;
+
+    /** @var CreateManagerInterface&MockObject */
+    private CreateManagerInterface $createRefundManager;
+
+    /** @var PaymentTransitionProcessorInterface&MockObject */
+    private PaymentTransitionProcessorInterface $paymentTransitionProcessor;
+
+    /** @var StateMachineInterface&MockObject */
+    private StateMachineInterface $stateMachine;
+
+    private RefundPaymentRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->paymentRequestProvider = $this->createMock(PaymentRequestProviderInterface::class);
+        $this->retrievePaymentIntentManager = $this->createMock(RetrieveManagerInterface::class);
+        $this->createRefundManager = $this->createMock(CreateManagerInterface::class);
+        $this->paymentTransitionProcessor = $this->createMock(PaymentTransitionProcessorInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+
+        $this->handler = new RefundPaymentRequestHandler(
+            $this->paymentRequestProvider,
+            $this->retrievePaymentIntentManager,
+            $this->createRefundManager,
+            $this->paymentTransitionProcessor,
+            $this->stateMachine,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function benignRefundRejections(): iterable
+    {
+        yield 'already refunded' => [
+            'Charge ch_123 has already been refunded.',
+            ErrorObject::CODE_CHARGE_ALREADY_REFUNDED,
+        ];
+        yield 'charged back' => [
+            'Charge ch_123 has been charged back; cannot issue a refund.',
+            ErrorObject::CODE_CHARGE_DISPUTED,
+        ];
+    }
+
+    #[DataProvider('benignRefundRejections')]
+    public function test_it_fails_the_payment_request_when_stripe_rejects_an_already_settled_refund(
+        string $message,
+        string $code,
+    ): void {
+        $command = new RefundPaymentRequest('hash', 1000);
+
+        $paymentRequest = $this->createPaymentRequestExpectingRetrievablePaymentIntent($command);
+
+        $exception = new InvalidRequestException($message);
+        $exception->setStripeCode($code);
+        $this->createRefundManager->method('create')->willThrowException($exception);
+
+        $paymentRequest->expects(self::once())
+            ->method('setResponseData')
+            ->with(['reason' => $message]);
+
+        $this->stateMachine->expects(self::once())
+            ->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->paymentTransitionProcessor->expects(self::never())->method('process');
+
+        $this->handler->__invoke($command);
+    }
+
+    public function test_it_rethrows_unexpected_stripe_invalid_request_errors(): void
+    {
+        $command = new RefundPaymentRequest('hash', 1000);
+
+        $paymentRequest = $this->createPaymentRequestExpectingRetrievablePaymentIntent($command);
+
+        $exception = new InvalidRequestException('Refund amount is greater than charge amount.');
+        $exception->setStripeCode(ErrorObject::CODE_AMOUNT_TOO_LARGE);
+        $this->createRefundManager->method('create')->willThrowException($exception);
+
+        $paymentRequest->expects(self::never())->method('setResponseData');
+        $this->stateMachine->expects(self::never())->method('apply');
+        $this->paymentTransitionProcessor->expects(self::never())->method('process');
+
+        $this->expectExceptionObject($exception);
+
+        $this->handler->__invoke($command);
+    }
+
+    /**
+     * @return PaymentRequestInterface&MockObject
+     */
+    private function createPaymentRequestExpectingRetrievablePaymentIntent(
+        RefundPaymentRequest $command,
+    ): PaymentRequestInterface {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getDetails')->willReturn(['id' => 'pi_123']);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->paymentRequestProvider->method('provide')->with($command)->willReturn($paymentRequest);
+
+        $paymentIntent = PaymentIntent::constructFrom([
+            'id' => 'pi_123',
+            'status' => PaymentIntent::STATUS_SUCCEEDED,
+            'amount' => 1000,
+        ]);
+        $this->retrievePaymentIntentManager->method('retrieve')->willReturn($paymentIntent);
+
+        return $paymentRequest;
+    }
+}


### PR DESCRIPTION
Closes #23

When a charge was refunded or charged back directly on the Stripe side, issuing a refund from Sylius made Stripe throw an unhandled `InvalidRequestException` (`Charge ... has already been refunded` / `Charge ... has been charged back; cannot issue a refund`), resulting in a 500 and the payment stuck in its current state.

Both refund handlers (Checkout and Web Elements) now catch that exception and, **only** for the two codes where the money has already left the merchant (`charge_already_refunded`, `charge_disputed`), fail the `PaymentRequest` gracefully instead of erroring. Any other invalid request keeps propagating, so genuine integration problems still surface and the refund isn't silently closed.

Partial refunds remain out of scope (to be addressed alongside Refund Plugin support).