### PR TITLE
[Shop][ExpressCheckout] Render buttons only when a payment method supports it

### DIFF
--- a/config/services/integrations/sylius_shop/express_checkout.php
+++ b/config/services/integrations/sylius_shop/express_checkout.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use FluxSE\SyliusStripePlugin\ExpressCheckout\ConfigurationProvider;
 use FluxSE\SyliusStripePlugin\ExpressCheckout\ConfigurationProviderInterface;
+use FluxSE\SyliusStripePlugin\ExpressCheckout\ExpressCheckoutAvailabilityChecker;
+use FluxSE\SyliusStripePlugin\ExpressCheckout\ExpressCheckoutAvailabilityCheckerInterface;
 use FluxSE\SyliusStripePlugin\ExpressCheckout\OrderCompleter;
 use FluxSE\SyliusStripePlugin\ExpressCheckout\OrderCompleterInterface;
 use FluxSE\SyliusStripePlugin\ExpressCheckout\Payload\ExpressCheckoutPayloadReader;
@@ -15,7 +17,6 @@ use FluxSE\SyliusStripePlugin\ExpressCheckout\Shipping\ShippingRateAssemblerInte
 use FluxSE\SyliusStripePlugin\ExpressCheckout\ShippingOptionsCalculator;
 use FluxSE\SyliusStripePlugin\ExpressCheckout\ShippingOptionsCalculatorInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
@@ -45,6 +46,13 @@ return static function (ContainerConfigurator $container): void {
             service('flux_se.sylius_stripe.resolver.express_checkout_payment_method'),
         ]);
     $services->alias(ConfigurationProviderInterface::class, 'flux_se.sylius_stripe.shop.express_checkout.configuration_provider');
+
+    $services->set('flux_se.sylius_stripe.shop.express_checkout.availability_checker', ExpressCheckoutAvailabilityChecker::class)
+        ->args([
+            service('sylius.context.channel'),
+            service('flux_se.sylius_stripe.resolver.express_checkout_payment_method'),
+        ]);
+    $services->alias(ExpressCheckoutAvailabilityCheckerInterface::class, 'flux_se.sylius_stripe.shop.express_checkout.availability_checker');
 
     $services->set('flux_se.sylius_stripe.shop.express_checkout.shipping_options_calculator', ShippingOptionsCalculator::class)
         ->args([

--- a/config/services/twig_extensions.php
+++ b/config/services/twig_extensions.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use FluxSE\SyliusStripePlugin\ExpressCheckout\ExpressCheckoutAvailabilityCheckerInterface;
 use FluxSE\SyliusStripePlugin\Stripe\SecretKey\LegacyKeyDetectorInterface;
 use FluxSE\SyliusStripePlugin\Stripe\SecretKey\LegacyStripePaymentMethodsProviderInterface;
+use FluxSE\SyliusStripePlugin\Twig\Extension\ExpressCheckoutExtension;
 use FluxSE\SyliusStripePlugin\Twig\Extension\LegacyStripeKeyExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -15,6 +17,12 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             service(LegacyKeyDetectorInterface::class),
             service(LegacyStripePaymentMethodsProviderInterface::class),
+        ])
+        ->tag('twig.extension');
+
+    $services->set('flux_se.sylius_stripe.twig.extension.express_checkout', ExpressCheckoutExtension::class)
+        ->args([
+            service(ExpressCheckoutAvailabilityCheckerInterface::class),
         ])
         ->tag('twig.extension');
 };

--- a/src/ExpressCheckout/ExpressCheckoutAvailabilityChecker.php
+++ b/src/ExpressCheckout/ExpressCheckoutAvailabilityChecker.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\ExpressCheckout;
+
+use FluxSE\SyliusStripePlugin\Resolver\ExpressCheckoutPaymentMethodResolverInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Core\Model\ChannelInterface;
+
+final readonly class ExpressCheckoutAvailabilityChecker implements ExpressCheckoutAvailabilityCheckerInterface
+{
+    public function __construct(
+        private ChannelContextInterface $channelContext,
+        private ExpressCheckoutPaymentMethodResolverInterface $paymentMethodResolver,
+    ) {
+    }
+
+    public function isAvailable(): bool
+    {
+        try {
+            $channel = $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException) {
+            return false;
+        }
+
+        if (!$channel instanceof ChannelInterface) {
+            return false;
+        }
+
+        return null !== $this->paymentMethodResolver->resolveForChannel($channel);
+    }
+}

--- a/src/ExpressCheckout/ExpressCheckoutAvailabilityCheckerInterface.php
+++ b/src/ExpressCheckout/ExpressCheckoutAvailabilityCheckerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\ExpressCheckout;
+
+interface ExpressCheckoutAvailabilityCheckerInterface
+{
+    public function isAvailable(): bool;
+}

--- a/src/Twig/Extension/ExpressCheckoutExtension.php
+++ b/src/Twig/Extension/ExpressCheckoutExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\Twig\Extension;
+
+use FluxSE\SyliusStripePlugin\ExpressCheckout\ExpressCheckoutAvailabilityCheckerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class ExpressCheckoutExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly ExpressCheckoutAvailabilityCheckerInterface $availabilityChecker,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'sylius_stripe_is_express_checkout_available',
+                $this->availabilityChecker->isAvailable(...),
+            ),
+        ];
+    }
+}

--- a/templates/shop/express_checkout/_button.html.twig
+++ b/templates/shop/express_checkout/_button.html.twig
@@ -1,11 +1,13 @@
-{% set placement = hookable_metadata.context.placement %}
-<div class="mt-3"
-     data-sylius-stripe-express-checkout
-     data-sylius-stripe-express-checkout-{{ placement }}
-     data-configuration-url="{{ path('sylius_stripe_express_checkout_configuration') }}"
-     data-shipping-rates-url="{{ path('sylius_stripe_express_checkout_shipping_rates') }}"
-     data-confirm-url="{{ path('sylius_stripe_express_checkout_confirm') }}"
-     data-csrf-token="{{ csrf_token(constant('FluxSE\\SyliusStripePlugin\\ExpressCheckout\\ExpressCheckoutCsrf::TOKEN_ID')) }}">
-    <div data-sylius-stripe-express-checkout-mount></div>
-    <div class="text-danger small mt-2" data-sylius-stripe-express-checkout-errors hidden></div>
-</div>
+{% if sylius_stripe_is_express_checkout_available() %}
+    {% set placement = hookable_metadata.context.placement %}
+    <div class="mt-3"
+         data-sylius-stripe-express-checkout
+         data-sylius-stripe-express-checkout-{{ placement }}
+         data-configuration-url="{{ path('sylius_stripe_express_checkout_configuration') }}"
+         data-shipping-rates-url="{{ path('sylius_stripe_express_checkout_shipping_rates') }}"
+         data-confirm-url="{{ path('sylius_stripe_express_checkout_confirm') }}"
+         data-csrf-token="{{ csrf_token(constant('FluxSE\\SyliusStripePlugin\\ExpressCheckout\\ExpressCheckoutCsrf::TOKEN_ID')) }}">
+        <div data-sylius-stripe-express-checkout-mount></div>
+        <div class="text-danger small mt-2" data-sylius-stripe-express-checkout-errors hidden></div>
+    </div>
+{% endif %}

--- a/tests/Functional/DataFixtures/ORM/express_checkout/payment_method_disabled.yaml
+++ b/tests/Functional/DataFixtures/ORM/express_checkout/payment_method_disabled.yaml
@@ -1,0 +1,29 @@
+Sylius\Component\Payment\Model\PaymentMethodTranslation:
+    payment_method_stripe_web_elements_express_checkout_disabled_translation:
+        name: 'Stripe Web Elements (Express Checkout disabled)'
+        locale: 'en_US'
+        description: '<paragraph(2)>'
+        translatable: '@payment_method_stripe_web_elements_express_checkout_disabled'
+
+Sylius\Component\Core\Model\PaymentMethod:
+    payment_method_stripe_web_elements_express_checkout_disabled:
+        code: 'STRIPE_WEB_ELEMENTS_ECE_DISABLED'
+        enabled: true
+        gatewayConfig: '@gateway_stripe_web_elements_express_checkout_disabled'
+        currentLocale: 'en_US'
+        translations:
+            - '@payment_method_stripe_web_elements_express_checkout_disabled_translation'
+        channels: ['@channel_web']
+
+Sylius\Bundle\PayumBundle\Model\GatewayConfig:
+    gateway_stripe_web_elements_express_checkout_disabled:
+        gatewayName: 'Stripe (Web Elements, Express Checkout disabled)'
+        factoryName: 'stripe_web_elements'
+        config:
+            use_payum: false
+            use_authorize: false
+            enable_express_checkout: false
+            publishable_key: 'pk_test_ece_123'
+            secret_key: 'rk_test_ece_123'
+            webhook_secret_keys:
+                - 'whsec_test_ece_123'

--- a/tests/Functional/Twig/CheckoutSidebarExpressCheckoutTest.php
+++ b/tests/Functional/Twig/CheckoutSidebarExpressCheckoutTest.php
@@ -62,6 +62,31 @@ final class CheckoutSidebarExpressCheckoutTest extends WebTestCase
         self::assertStringContainsString('data-sylius-stripe-express-checkout-mount', $content);
     }
 
+    public function test_it_does_not_render_express_checkout_button_when_no_payment_method_supports_it(): void
+    {
+        $fixtures = $this->loadFixtures([
+            'channel.yaml',
+            'tax_category.yaml',
+            'shipping_category.yaml',
+            'product_variant.yaml',
+            'express_checkout/payment_method_disabled.yaml',
+            'express_checkout/cart_ready.yaml',
+        ]);
+
+        /** @var OrderInterface $cart */
+        $cart = $fixtures['cart_ready'];
+        $this->startCartSession($cart);
+
+        $this->client->request('GET', '/en_US/checkout/address');
+
+        $response = $this->client->getResponse();
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $content = (string) $response->getContent();
+        self::assertStringNotContainsString('data-sylius-stripe-express-checkout-checkout', $content);
+        self::assertStringNotContainsString('data-sylius-stripe-express-checkout-mount', $content);
+    }
+
     private function startCartSession(OrderInterface $cart): void
     {
         /** @var SessionFactoryInterface $sessionFactory */

--- a/tests/Unit/ExpressCheckout/ExpressCheckoutAvailabilityCheckerTest.php
+++ b/tests/Unit/ExpressCheckout/ExpressCheckoutAvailabilityCheckerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\SyliusStripePlugin\Unit\ExpressCheckout;
+
+use FluxSE\SyliusStripePlugin\ExpressCheckout\ExpressCheckoutAvailabilityChecker;
+use FluxSE\SyliusStripePlugin\Resolver\ExpressCheckoutPaymentMethodResolverInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+final class ExpressCheckoutAvailabilityCheckerTest extends TestCase
+{
+    public function test_it_is_available_when_the_resolver_finds_a_payment_method(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+
+        $checker = $this->createChecker($channel, $paymentMethod);
+
+        self::assertTrue($checker->isAvailable());
+    }
+
+    public function test_it_is_not_available_when_the_resolver_finds_no_payment_method(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $checker = $this->createChecker($channel, null);
+
+        self::assertFalse($checker->isAvailable());
+    }
+
+    public function test_it_is_not_available_when_no_channel_is_found(): void
+    {
+        $channelContext = $this->createMock(ChannelContextInterface::class);
+        $channelContext->method('getChannel')->willThrowException(new ChannelNotFoundException());
+
+        $resolver = $this->createMock(ExpressCheckoutPaymentMethodResolverInterface::class);
+        $resolver->expects($this->never())->method('resolveForChannel');
+
+        $checker = new ExpressCheckoutAvailabilityChecker($channelContext, $resolver);
+
+        self::assertFalse($checker->isAvailable());
+    }
+
+    private function createChecker(
+        ChannelInterface $channel,
+        ?PaymentMethodInterface $resolved,
+    ): ExpressCheckoutAvailabilityChecker {
+        $channelContext = $this->createMock(ChannelContextInterface::class);
+        $channelContext->method('getChannel')->willReturn($channel);
+
+        $resolver = $this->createMock(ExpressCheckoutPaymentMethodResolverInterface::class);
+        $resolver->method('resolveForChannel')->with($channel)->willReturn($resolved);
+
+        return new ExpressCheckoutAvailabilityChecker($channelContext, $resolver);
+    }
+}


### PR DESCRIPTION
Related issue: https://github.com/Sylius/StripePlugin/issues/123
This fix prevents rendering an empty DIV and executing JS when Express Checkout is disabled.