### PR TITLE
Sylius 2.3 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ "8.4", "8.5" ]
-                symfony: [ "^6.4", "^7.4" ]
-                sylius: [ "~2.2.0" ]
+                symfony: [ "^7.4", "^8.4" ]
+                sylius: [ "~2.3.0" ]
 
         steps:
             -
@@ -101,8 +101,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ "8.4", "8.5" ]
-                symfony: [ "^6.4", "^7.4" ]
-                sylius: [ "~2.2.0" ]
+                symfony: [ "^7.4", "^8.4" ]
+                sylius: [ "~2.3.0" ]
                 node: ["20.x"]
                 mysql: ["8.0"]
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
                 php: [ "8.4", "8.5" ]
                 symfony: [ "^7.4", "^8.4" ]
                 sylius: [ "~2.3.0" ]
-                node: ["20.x"]
+                node: ["22.x"]
                 mysql: ["8.0"]
 
         env:

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,15 @@
             "email": "Prometee@users.noreply.github.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/rust-le/TestApplication.git"
+        }
+    ],
     "require": {
         "stripe/stripe-php": "^20.0",
-        "sylius/core-bundle": "^2.0",
+        "sylius/core-bundle": "^2.3",
         "sylius/telemetry": "^1.0"
     },
     "require-dev": {
@@ -41,16 +47,17 @@
         "spaze/phpstan-stripe": "^3.2",
         "sylius-labs/coding-standard": "^4.1",
         "sylius-labs/suite-tags-extension": "^0.2.0",
-        "sylius/sylius": "^2.0",
-        "sylius/test-application": "^2.0.0@alpha",
-        "symfony/browser-kit": "^6.4 || ^7.4",
-        "symfony/debug-bundle": "^6.4 || ^7.4",
-        "symfony/dotenv": "^6.4 || ^7.4",
-        "symfony/intl": "^6.4 || ^7.4",
-        "symfony/runtime": "^7.1",
-        "symfony/web-profiler-bundle": "^6.4 || ^7.4",
+        "sylius/sylius": "^2.3",
+        "sylius/test-application": "dev-sylius-2.3-symfony-8",
+        "symfony/browser-kit": "^7.4 || ^8.4",
+        "symfony/debug-bundle": "^7.4 || ^8.4",
+        "symfony/dotenv": "^7.4 || ^8.4",
+        "symfony/intl": "^7.4 || ^8.4",
+        "symfony/runtime": "^7.4 || ^8.0",
+        "symfony/web-profiler-bundle": "^7.4 || ^8.4",
         "theofidry/alice-data-fixtures": "^1.7"
     },
+    "minimum-stability": "dev",
     "suggest": {
         "sylius/shop-bundle": "Use the Sylius default front shop",
         "sylius/admin-bundle": "Use the Sylius default admin",

--- a/src/Form/Type/StripeAppearanceType.php
+++ b/src/Form/Type/StripeAppearanceType.php
@@ -49,44 +49,44 @@ final class StripeAppearanceType extends AbstractType
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_primary',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('colorBackground', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_background',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('colorText', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_text',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('colorDanger', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_danger',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('fontFamily', TextType::class, [
@@ -97,22 +97,22 @@ final class StripeAppearanceType extends AbstractType
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::BORDER_RADIUS_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::BORDER_RADIUS_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('spacingUnit', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.spacing_unit',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::BORDER_RADIUS_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::BORDER_RADIUS_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
         ;

--- a/src/Form/Type/StripeGatewayConfigurationType.php
+++ b/src/Form/Type/StripeGatewayConfigurationType.php
@@ -27,23 +27,23 @@ final class StripeGatewayConfigurationType extends AbstractType
                     'placeholder' => 'pk_',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.publishable_key.not_blank',
-                        'groups' => [
+                    new NotBlank(
+                        message: 'flux_se_sylius_stripe_plugin.stripe.publishable_key.not_blank',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
-                    new Regex([
-                        'pattern' => self::PUBLISHABLE_KEY_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.publishable_key.invalid_format',
-                        'groups' => [
+                    ),
+                    new Regex(
+                        pattern: self::PUBLISHABLE_KEY_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe.publishable_key.invalid_format',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
+                    ),
                 ],
             ])
             ->add('secret_key', TextType::class, [
@@ -52,23 +52,23 @@ final class StripeGatewayConfigurationType extends AbstractType
                     'placeholder' => 'rk_',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.secret_key.not_blank',
-                        'groups' => [
+                    new NotBlank(
+                        message: 'flux_se_sylius_stripe_plugin.stripe.secret_key.not_blank',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
-                    new Regex([
-                        'pattern' => self::SECRET_KEY_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.secret_key.invalid_format',
-                        'groups' => [
+                    ),
+                    new Regex(
+                        pattern: self::SECRET_KEY_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe.secret_key.invalid_format',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
+                    ),
                 ],
             ])
             ->add('use_authorize', CheckboxType::class, [
@@ -93,14 +93,14 @@ final class StripeGatewayConfigurationType extends AbstractType
                 ],
                 'error_bubbling' => false,
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.webhook_secret_keys.not_blank',
-                        'groups' => [
+                    new NotBlank(
+                        message: 'flux_se_sylius_stripe_plugin.stripe.webhook_secret_keys.not_blank',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
+                    ),
                 ],
                 'entry_options' => [
                     'label' => false,

--- a/src/OrderPay/Provider/Checkout/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/Checkout/CaptureHttpResponseProvider.php
@@ -5,22 +5,22 @@ declare(strict_types=1);
 namespace FluxSE\SyliusStripePlugin\OrderPay\Provider\Checkout;
 
 use Sylius\Bundle\PaymentBundle\Provider\HttpResponseProviderInterface;
-use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final readonly class CaptureHttpResponseProvider implements HttpResponseProviderInterface
 {
     public function supports(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): bool {
         return $paymentRequest->getState() === PaymentRequestInterface::STATE_PROCESSING;
     }
 
     public function getResponse(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): Response {
         $data = $paymentRequest->getResponseData();

--- a/src/OrderPay/Provider/WebElements/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/WebElements/CaptureHttpResponseProvider.php
@@ -8,8 +8,8 @@ use FluxSE\SyliusStripePlugin\Appearance\AppearanceBuilder;
 use FluxSE\SyliusStripePlugin\Provider\AfterUrlProviderInterface;
 use Stripe\PaymentIntent;
 use Sylius\Bundle\PaymentBundle\Provider\HttpResponseProviderInterface;
-use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
@@ -23,14 +23,14 @@ final readonly class CaptureHttpResponseProvider implements HttpResponseProvider
     }
 
     public function supports(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): bool {
         return $paymentRequest->getState() === PaymentRequestInterface::STATE_PROCESSING;
     }
 
     public function getResponse(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): Response {
         $data = $paymentRequest->getResponseData();

--- a/tests/TestApplication/config/services_test.php
+++ b/tests/TestApplication/config/services_test.php
@@ -12,6 +12,6 @@ return function (ContainerConfigurator $container): void {
 
     $repoRoot = \dirname(__DIR__, 3);
 
-    $container->import($repoRoot . '/vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.xml');
+    $container->import($repoRoot . '/vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.php');
     $container->import($repoRoot . '/tests/Behat/Resources/services.php');
 };

--- a/tests/Unit/Form/Type/StripeAppearanceTypeTest.php
+++ b/tests/Unit/Form/Type/StripeAppearanceTypeTest.php
@@ -23,7 +23,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('acceptedColorProvider')]
     public function test_color_field_accepts_valid_hex(string $color): void
     {
-        $violations = $this->validator->validate($color, new Regex(['pattern' => StripeAppearanceType::COLOR_PATTERN]));
+        $violations = $this->validator->validate($color, new Regex(pattern: StripeAppearanceType::COLOR_PATTERN));
 
         self::assertCount(0, $violations, sprintf('Expected "%s" to be accepted.', $color));
     }
@@ -41,7 +41,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('rejectedColorProvider')]
     public function test_color_field_rejects_invalid_hex(string $color): void
     {
-        $violations = $this->validator->validate($color, new Regex(['pattern' => StripeAppearanceType::COLOR_PATTERN]));
+        $violations = $this->validator->validate($color, new Regex(pattern: StripeAppearanceType::COLOR_PATTERN));
 
         self::assertGreaterThan(0, $violations->count(), sprintf('Expected "%s" to be rejected.', $color));
     }
@@ -60,7 +60,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('acceptedBorderRadiusProvider')]
     public function test_border_radius_field_accepts_valid_values(string $value): void
     {
-        $violations = $this->validator->validate($value, new Regex(['pattern' => StripeAppearanceType::BORDER_RADIUS_PATTERN]));
+        $violations = $this->validator->validate($value, new Regex(pattern: StripeAppearanceType::BORDER_RADIUS_PATTERN));
 
         self::assertCount(0, $violations, sprintf('Expected "%s" to be accepted.', $value));
     }
@@ -79,7 +79,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('rejectedBorderRadiusProvider')]
     public function test_border_radius_field_rejects_invalid_values(string $value): void
     {
-        $violations = $this->validator->validate($value, new Regex(['pattern' => StripeAppearanceType::BORDER_RADIUS_PATTERN]));
+        $violations = $this->validator->validate($value, new Regex(pattern: StripeAppearanceType::BORDER_RADIUS_PATTERN));
 
         self::assertGreaterThan(0, $violations->count(), sprintf('Expected "%s" to be rejected.', $value));
     }

--- a/tests/Unit/Form/Type/StripeGatewayConfigurationTypeTest.php
+++ b/tests/Unit/Form/Type/StripeGatewayConfigurationTypeTest.php
@@ -162,7 +162,7 @@ final class StripeGatewayConfigurationTypeTest extends TestCase
     {
         return [
             new NotBlank(),
-            new Regex(['pattern' => StripeGatewayConfigurationType::SECRET_KEY_PATTERN]),
+            new Regex(pattern: StripeGatewayConfigurationType::SECRET_KEY_PATTERN),
         ];
     }
 
@@ -171,7 +171,7 @@ final class StripeGatewayConfigurationTypeTest extends TestCase
     {
         return [
             new NotBlank(),
-            new Regex(['pattern' => StripeGatewayConfigurationType::PUBLISHABLE_KEY_PATTERN]),
+            new Regex(pattern: StripeGatewayConfigurationType::PUBLISHABLE_KEY_PATTERN),
         ];
     }
 }


### PR DESCRIPTION
This pull request updates dependencies to support newer versions of Symfony and Sylius, adjusts the test application and workflow configuration accordingly, and refactors provider classes to use the Symfony `Request` object instead of the Sylius `RequestConfiguration`. These changes ensure compatibility with the latest frameworks and simplify integration points.

**Dependency and compatibility updates:**

* Updated `composer.json` to require Sylius `^2.3` and Symfony components `^7.4`/`^8.4`.
* _[temporarily] Adjusted related dev dependencies to match these versions. Also set `minimum-stability` to `dev` and added a custom repository for the test application. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R13-R21) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L44-R60)_
* Updated GitHub Actions workflow matrices in `.github/workflows/build.yaml` to test against the new Symfony `^7.4`/`^8.4` and Sylius `~2.3.0` versions. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L22-R23) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L104-R105)

**Code refactoring for framework compatibility:**

* Refactored `CaptureHttpResponseProvider` classes in `src/OrderPay/Provider/Checkout` and `src/OrderPay/Provider/WebElements` to use Symfony's `Request` instead of Sylius's `RequestConfiguration` in method signatures, aligning with the latest Sylius and Symfony best practices. [[1]](diffhunk://#diff-2150e8a748838e11b83689733784b65dff86a3bdc0e662d8ca19e1c5418304bdL8-R23) [[2]](diffhunk://#diff-1ab53e767d4856c52d7b42c0ccb6e1254b01324c83a316360eda91826acc3c80L11-R12) [[3]](diffhunk://#diff-1ab53e767d4856c52d7b42c0ccb6e1254b01324c83a316360eda91826acc3c80L26-R33)