### PR TITLE
Fix/pr 132 ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ "8.4", "8.5" ]
-                symfony: [ "^6.4", "^7.4" ]
-                sylius: [ "~2.2.0" ]
+                symfony: [ "^7.4", "^8.4" ]
+                sylius: [ "~2.3.0" ]
 
         steps:
             -
@@ -101,8 +101,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ "8.4", "8.5" ]
-                symfony: [ "^6.4", "^7.4" ]
-                sylius: [ "~2.2.0" ]
+                symfony: [ "^7.4", "^8.4" ]
+                sylius: [ "~2.3.0" ]
                 node: ["20.x"]
                 mysql: ["8.0"]
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
                 php: [ "8.4", "8.5" ]
                 symfony: [ "^7.4", "^8.4" ]
                 sylius: [ "~2.3.0" ]
-                node: ["20.x"]
+                node: ["22.x"]
                 mysql: ["8.0"]
 
         env:

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,15 @@
             "email": "Prometee@users.noreply.github.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/rust-le/TestApplication.git"
+        }
+    ],
     "require": {
         "stripe/stripe-php": "^20.0",
-        "sylius/core-bundle": "^2.0",
+        "sylius/core-bundle": "^2.3",
         "sylius/telemetry": "^1.0"
     },
     "require-dev": {
@@ -41,16 +47,17 @@
         "spaze/phpstan-stripe": "^3.2",
         "sylius-labs/coding-standard": "^4.1",
         "sylius-labs/suite-tags-extension": "^0.2.0",
-        "sylius/sylius": "^2.0",
-        "sylius/test-application": "^2.0.0@alpha",
-        "symfony/browser-kit": "^6.4 || ^7.4",
-        "symfony/debug-bundle": "^6.4 || ^7.4",
-        "symfony/dotenv": "^6.4 || ^7.4",
-        "symfony/intl": "^6.4 || ^7.4",
-        "symfony/runtime": "^7.1",
-        "symfony/web-profiler-bundle": "^6.4 || ^7.4",
+        "sylius/sylius": "^2.3",
+        "sylius/test-application": "dev-sylius-2.3-symfony-8",
+        "symfony/browser-kit": "^7.4 || ^8.4",
+        "symfony/debug-bundle": "^7.4 || ^8.4",
+        "symfony/dotenv": "^7.4 || ^8.4",
+        "symfony/intl": "^7.4 || ^8.4",
+        "symfony/runtime": "^7.4 || ^8.0",
+        "symfony/web-profiler-bundle": "^7.4 || ^8.4",
         "theofidry/alice-data-fixtures": "^1.7"
     },
+    "minimum-stability": "dev",
     "suggest": {
         "sylius/shop-bundle": "Use the Sylius default front shop",
         "sylius/admin-bundle": "Use the Sylius default admin",

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "theofidry/alice-data-fixtures": "^1.7"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "suggest": {
         "sylius/shop-bundle": "Use the Sylius default front shop",
         "sylius/admin-bundle": "Use the Sylius default admin",

--- a/config/services/api_platform.php
+++ b/config/services/api_platform.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use FluxSE\SyliusStripePlugin\ApiPlatform\Metadata\PaymentRequestRelationPropertyMetadataFactory;
+use FluxSE\SyliusStripePlugin\ApiPlatform\Routing\StaleItemUriTemplateIriConverter;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+
+    $services
+        ->set('flux_se.sylius_stripe.api_platform.routing.iri_converter', StaleItemUriTemplateIriConverter::class)
+        ->decorate('api_platform.symfony.iri_converter', null, 48)
+        ->args([
+            service('.inner'),
+            service('api_platform.metadata.operation.metadata_factory'),
+        ])
+    ;
+
+    $services
+        ->set('flux_se.sylius_stripe.api_platform.property_metadata_factory', PaymentRequestRelationPropertyMetadataFactory::class)
+        ->decorate('api_platform.metadata.property.metadata_factory', null, -20)
+        ->args([
+            service('.inner'),
+            param('sylius.model.payment_request.class'),
+            param('sylius.model.payment.class'),
+            param('sylius.model.payment_method.class'),
+        ])
+    ;
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -54,3 +54,5 @@ parameters:
         - message: '/Call to method arrayNode\(\) on an unknown class Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition>\./'
           paths:
               - src/DependencyInjection/Configuration.php
+        - message: '/PHPDoc tag @param for parameter \$event contains generic type Symfony\\Component\\Workflow\\Event\\CompletedEvent<.+> but class Symfony\\Component\\Workflow\\Event\\CompletedEvent is not generic\./'
+          path: src/EventListener/Workflow/PaymentCompletedStateListener.php

--- a/src/ApiPlatform/Metadata/PaymentRequestRelationPropertyMetadataFactory.php
+++ b/src/ApiPlatform/Metadata/PaymentRequestRelationPropertyMetadataFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use Symfony\Component\TypeInfo\Type;
+
+final readonly class PaymentRequestRelationPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+{
+    /** @var array<string, class-string> */
+    private array $resourceClassByProperty;
+
+    /**
+     * @param class-string $paymentRequestResourceClass
+     * @param class-string $paymentResourceClass
+     * @param class-string $paymentMethodResourceClass
+     */
+    public function __construct(
+        private PropertyMetadataFactoryInterface $decorated,
+        private string $paymentRequestResourceClass,
+        string $paymentResourceClass,
+        string $paymentMethodResourceClass,
+    ) {
+        $this->resourceClassByProperty = [
+            'payment' => $paymentResourceClass,
+            'method' => $paymentMethodResourceClass,
+        ];
+    }
+
+    public function create(string $resourceClass, string $property, array $options = []): ApiProperty
+    {
+        $propertyMetadata = $this->decorated->create($resourceClass, $property, $options);
+
+        $targetClass = $this->resourceClassByProperty[$property] ?? null;
+
+        if (null === $targetClass || !is_a($resourceClass, $this->paymentRequestResourceClass, true)) {
+            return $propertyMetadata;
+        }
+
+        $nativeType = $propertyMetadata->getNativeType();
+
+        if (null === $nativeType) {
+            return $propertyMetadata;
+        }
+
+        $resolvedType = Type::object($targetClass);
+
+        return $propertyMetadata->withNativeType($nativeType->isNullable() ? Type::nullable($resolvedType) : $resolvedType);
+    }
+}

--- a/src/ApiPlatform/Routing/StaleItemUriTemplateIriConverter.php
+++ b/src/ApiPlatform/Routing/StaleItemUriTemplateIriConverter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusStripePlugin\ApiPlatform\Routing;
+
+use ApiPlatform\Metadata\IriConverterInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
+
+final readonly class StaleItemUriTemplateIriConverter implements IriConverterInterface
+{
+    public function __construct(
+        private IriConverterInterface $decoratedIriConverter,
+        private OperationMetadataFactoryInterface $operationMetadataFactory,
+    ) {
+    }
+
+    public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null): object
+    {
+        return $this->decoratedIriConverter->getResourceFromIri($iri, $context, $operation);
+    }
+
+    public function getIriFromResource(
+        object|string $resource,
+        int $referenceType = UrlGeneratorInterface::ABS_PATH,
+        ?Operation $operation = null,
+        array $context = [],
+    ): ?string {
+        $itemUriTemplate = $context['item_uri_template'] ?? null;
+
+        if (is_object($resource) && is_string($itemUriTemplate)) {
+            $itemOperation = $this->operationMetadataFactory->create($itemUriTemplate);
+            $itemOperationClass = $itemOperation?->getClass();
+
+            if (null !== $itemOperationClass && !is_a($resource, $itemOperationClass)) {
+                unset($context['item_uri_template']);
+            }
+        }
+
+        return $this->decoratedIriConverter->getIriFromResource($resource, $referenceType, $operation, $context);
+    }
+}

--- a/src/EventListener/Workflow/PaymentCompletedStateListener.php
+++ b/src/EventListener/Workflow/PaymentCompletedStateListener.php
@@ -16,6 +16,9 @@ final class PaymentCompletedStateListener
     ) {
     }
 
+    /**
+     * @param CompletedEvent<PaymentInterface> $event
+     */
     public function __invoke(CompletedEvent $event): void
     {
         /** @var PaymentInterface|object $payment */

--- a/src/Form/Type/StripeAppearanceType.php
+++ b/src/Form/Type/StripeAppearanceType.php
@@ -49,44 +49,44 @@ final class StripeAppearanceType extends AbstractType
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_primary',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('colorBackground', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_background',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('colorText', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_text',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('colorDanger', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color_danger',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::COLOR_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::COLOR_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.color',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('fontFamily', TextType::class, [
@@ -97,22 +97,22 @@ final class StripeAppearanceType extends AbstractType
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::BORDER_RADIUS_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::BORDER_RADIUS_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
             ->add('spacingUnit', TextType::class, [
                 'label' => 'flux_se_sylius_stripe_plugin.stripe_appearance.spacing_unit',
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => self::BORDER_RADIUS_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
-                        'groups' => ['sylius', 'stripe_web_elements'],
-                    ]),
+                    new Regex(
+                        pattern: self::BORDER_RADIUS_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe_appearance.border_radius',
+                        groups: ['sylius', 'stripe_web_elements'],
+                    ),
                 ],
             ])
         ;

--- a/src/Form/Type/StripeGatewayConfigurationType.php
+++ b/src/Form/Type/StripeGatewayConfigurationType.php
@@ -27,23 +27,23 @@ final class StripeGatewayConfigurationType extends AbstractType
                     'placeholder' => 'pk_',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.publishable_key.not_blank',
-                        'groups' => [
+                    new NotBlank(
+                        message: 'flux_se_sylius_stripe_plugin.stripe.publishable_key.not_blank',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
-                    new Regex([
-                        'pattern' => self::PUBLISHABLE_KEY_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.publishable_key.invalid_format',
-                        'groups' => [
+                    ),
+                    new Regex(
+                        pattern: self::PUBLISHABLE_KEY_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe.publishable_key.invalid_format',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
+                    ),
                 ],
             ])
             ->add('secret_key', TextType::class, [
@@ -52,23 +52,23 @@ final class StripeGatewayConfigurationType extends AbstractType
                     'placeholder' => 'rk_',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.secret_key.not_blank',
-                        'groups' => [
+                    new NotBlank(
+                        message: 'flux_se_sylius_stripe_plugin.stripe.secret_key.not_blank',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
-                    new Regex([
-                        'pattern' => self::SECRET_KEY_PATTERN,
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.secret_key.invalid_format',
-                        'groups' => [
+                    ),
+                    new Regex(
+                        pattern: self::SECRET_KEY_PATTERN,
+                        message: 'flux_se_sylius_stripe_plugin.stripe.secret_key.invalid_format',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
+                    ),
                 ],
             ])
             ->add('use_authorize', CheckboxType::class, [
@@ -93,14 +93,14 @@ final class StripeGatewayConfigurationType extends AbstractType
                 ],
                 'error_bubbling' => false,
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'flux_se_sylius_stripe_plugin.stripe.webhook_secret_keys.not_blank',
-                        'groups' => [
+                    new NotBlank(
+                        message: 'flux_se_sylius_stripe_plugin.stripe.webhook_secret_keys.not_blank',
+                        groups: [
                             'sylius',
                             'stripe_checkout',
                             'stripe_web_elements',
                         ],
-                    ]),
+                    ),
                 ],
                 'entry_options' => [
                     'label' => false,

--- a/src/OrderPay/Provider/Checkout/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/Checkout/CaptureHttpResponseProvider.php
@@ -5,22 +5,22 @@ declare(strict_types=1);
 namespace FluxSE\SyliusStripePlugin\OrderPay\Provider\Checkout;
 
 use Sylius\Bundle\PaymentBundle\Provider\HttpResponseProviderInterface;
-use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final readonly class CaptureHttpResponseProvider implements HttpResponseProviderInterface
 {
     public function supports(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): bool {
         return $paymentRequest->getState() === PaymentRequestInterface::STATE_PROCESSING;
     }
 
     public function getResponse(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): Response {
         $data = $paymentRequest->getResponseData();

--- a/src/OrderPay/Provider/WebElements/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/WebElements/CaptureHttpResponseProvider.php
@@ -8,8 +8,8 @@ use FluxSE\SyliusStripePlugin\Appearance\AppearanceBuilder;
 use FluxSE\SyliusStripePlugin\Provider\AfterUrlProviderInterface;
 use Stripe\PaymentIntent;
 use Sylius\Bundle\PaymentBundle\Provider\HttpResponseProviderInterface;
-use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
@@ -23,14 +23,14 @@ final readonly class CaptureHttpResponseProvider implements HttpResponseProvider
     }
 
     public function supports(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): bool {
         return $paymentRequest->getState() === PaymentRequestInterface::STATE_PROCESSING;
     }
 
     public function getResponse(
-        RequestConfiguration $requestConfiguration,
+        Request $request,
         PaymentRequestInterface $paymentRequest,
     ): Response {
         $data = $paymentRequest->getResponseData();

--- a/tests/TestApplication/config/services_test.php
+++ b/tests/TestApplication/config/services_test.php
@@ -12,6 +12,6 @@ return function (ContainerConfigurator $container): void {
 
     $repoRoot = \dirname(__DIR__, 3);
 
-    $container->import($repoRoot . '/vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.xml');
+    $container->import($repoRoot . '/vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.php');
     $container->import($repoRoot . '/tests/Behat/Resources/services.php');
 };

--- a/tests/Unit/Form/Type/StripeAppearanceTypeTest.php
+++ b/tests/Unit/Form/Type/StripeAppearanceTypeTest.php
@@ -23,7 +23,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('acceptedColorProvider')]
     public function test_color_field_accepts_valid_hex(string $color): void
     {
-        $violations = $this->validator->validate($color, new Regex(['pattern' => StripeAppearanceType::COLOR_PATTERN]));
+        $violations = $this->validator->validate($color, new Regex(pattern: StripeAppearanceType::COLOR_PATTERN));
 
         self::assertCount(0, $violations, sprintf('Expected "%s" to be accepted.', $color));
     }
@@ -41,7 +41,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('rejectedColorProvider')]
     public function test_color_field_rejects_invalid_hex(string $color): void
     {
-        $violations = $this->validator->validate($color, new Regex(['pattern' => StripeAppearanceType::COLOR_PATTERN]));
+        $violations = $this->validator->validate($color, new Regex(pattern: StripeAppearanceType::COLOR_PATTERN));
 
         self::assertGreaterThan(0, $violations->count(), sprintf('Expected "%s" to be rejected.', $color));
     }
@@ -60,7 +60,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('acceptedBorderRadiusProvider')]
     public function test_border_radius_field_accepts_valid_values(string $value): void
     {
-        $violations = $this->validator->validate($value, new Regex(['pattern' => StripeAppearanceType::BORDER_RADIUS_PATTERN]));
+        $violations = $this->validator->validate($value, new Regex(pattern: StripeAppearanceType::BORDER_RADIUS_PATTERN));
 
         self::assertCount(0, $violations, sprintf('Expected "%s" to be accepted.', $value));
     }
@@ -79,7 +79,7 @@ final class StripeAppearanceTypeTest extends TestCase
     #[DataProvider('rejectedBorderRadiusProvider')]
     public function test_border_radius_field_rejects_invalid_values(string $value): void
     {
-        $violations = $this->validator->validate($value, new Regex(['pattern' => StripeAppearanceType::BORDER_RADIUS_PATTERN]));
+        $violations = $this->validator->validate($value, new Regex(pattern: StripeAppearanceType::BORDER_RADIUS_PATTERN));
 
         self::assertGreaterThan(0, $violations->count(), sprintf('Expected "%s" to be rejected.', $value));
     }

--- a/tests/Unit/Form/Type/StripeGatewayConfigurationTypeTest.php
+++ b/tests/Unit/Form/Type/StripeGatewayConfigurationTypeTest.php
@@ -162,7 +162,7 @@ final class StripeGatewayConfigurationTypeTest extends TestCase
     {
         return [
             new NotBlank(),
-            new Regex(['pattern' => StripeGatewayConfigurationType::SECRET_KEY_PATTERN]),
+            new Regex(pattern: StripeGatewayConfigurationType::SECRET_KEY_PATTERN),
         ];
     }
 
@@ -171,7 +171,7 @@ final class StripeGatewayConfigurationTypeTest extends TestCase
     {
         return [
             new NotBlank(),
-            new Regex(['pattern' => StripeGatewayConfigurationType::PUBLISHABLE_KEY_PATTERN]),
+            new Regex(pattern: StripeGatewayConfigurationType::PUBLISHABLE_KEY_PATTERN),
         ];
     }
 }


### PR DESCRIPTION
Fix: PaymentRequestsTest was failing with a 400 ("Unable to generate an IRI…"), matching Sylius/Sylius#18189. Root cause: a stale item_uri_template from the PaymentRequest POST operation leaks into the payment/method relation context during serialization, and those relations are also mistyped for resource-class resolution. Both are neutralized locally via two small IriConverter/property-metadata decorators (no vendor changes). Also includes a prefer-stable Composer fix and a PHPStan generic-type fix for CompletedEvent across the Symfony 7.4/8.4 matrix.